### PR TITLE
Make MethodInvoker.Handler operate on stack instead of locals

### DIFF
--- a/Harmony/Extras/MethodInvoker.cs
+++ b/Harmony/Extras/MethodInvoker.cs
@@ -8,7 +8,7 @@ namespace Harmony
 
 	public delegate object FastInvokeHandler(object target, object[] paramters);
 
-	class MethodInvoker
+	public class MethodInvoker
 	{
 		public static FastInvokeHandler GetHandler(DynamicMethod methodInfo, Module module)
 		{

--- a/HarmonyTests/Extras/Assets/MethodInvokerClasses.cs
+++ b/HarmonyTests/Extras/Assets/MethodInvokerClasses.cs
@@ -1,0 +1,33 @@
+﻿using Harmony;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace HarmonyTests.Assets
+{
+    public class TestMethodInvokerObject
+    {
+        public int Value;
+        public void Method1(int a)
+        {
+            Value += a;
+        }
+    }
+    public struct TestMethodInvokerStruct
+    {
+        public int Value;
+    }
+    public static class MethodInvokerClass
+    {
+
+        public static void Method1(int a, ref int b, out int c, out TestMethodInvokerObject d, ref TestMethodInvokerStruct e)
+        {
+            b = b + 1;
+            c = b * 2;
+            d = new TestMethodInvokerObject();
+            d.Value = a;
+            e.Value = a;
+        }
+
+    }
+}

--- a/HarmonyTests/Extras/TestMethodInvoker.cs
+++ b/HarmonyTests/Extras/TestMethodInvoker.cs
@@ -1,0 +1,54 @@
+﻿using Harmony;
+using Harmony.ILCopying;
+using HarmonyTests.Assets;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Reflection;
+
+namespace HarmonyTests
+{
+	[TestClass]
+	public class TestMethodInvoker
+    {
+
+		[TestMethod]
+        public void TestMethodInvokerGeneral()
+        {
+            var type = typeof(MethodInvokerClass);
+            Assert.IsNotNull(type);
+            var method = type.GetMethod("Method1");
+            Assert.IsNotNull(method);
+
+            var handler = MethodInvoker.GetHandler(method);
+            Assert.IsNotNull(handler);
+
+            object[] args = new object[] { 1, 0, 0, /*out*/ null, /*ref*/ new TestMethodInvokerStruct() };
+            handler(null, args);
+            Assert.AreEqual(args[0], 1);
+            Assert.AreEqual(args[1], 1);
+            Assert.AreEqual(args[2], 2);
+            Assert.AreEqual(((TestMethodInvokerObject) args[3])?.Value, 1);
+            Assert.AreEqual(((TestMethodInvokerStruct) args[4]).Value, 1);
+        }
+
+        [TestMethod]
+        public void TestMethodInvokerSelfObject()
+        {
+            var type = typeof(TestMethodInvokerObject);
+            Assert.IsNotNull(type);
+            var method = type.GetMethod("Method1");
+            Assert.IsNotNull(method);
+
+            var handler = MethodInvoker.GetHandler(method);
+            Assert.IsNotNull(handler);
+
+            var instance = new TestMethodInvokerObject();
+            instance.Value = 1;
+
+            object[] args = new object[] { 2 };
+            handler(instance, args);
+            Assert.AreEqual(instance.Value, 3);
+        }
+
+    }
+}

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -75,7 +75,7 @@
     <ProjectReference Include="..\Harmony\Harmony.csproj">
       <Project>{69aee16a-b6e7-4642-8081-3928b32455df}</Project>
       <Name>Harmony</Name>
-      <Private>False</Private>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -55,7 +55,9 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Extras\Assets\MethodInvokerClasses.cs" />
     <Compile Include="Patching\Assets\PatchClasses.cs" />
+    <Compile Include="Extras\TestMethodInvoker.cs" />
     <Compile Include="Patching\StaticPatches.cs" />
     <Compile Include="Tools\Assets\AccessToolsClass.cs" />
     <Compile Include="Tools\Assets\AttributesClass.cs" />


### PR DESCRIPTION
MethodInvoker.Handler uses locals as a layer of indirection for the arguments, which is useful for reference types (`ref` and `out` parameters), but adds some overhead when invoking the method.

Recently, I've spent my time implementing `ref` support to the ReflectionHelper in MonoMod (offline .NET assembly patcher), but instead of using locals, I opted to operate on the stack. This means MonoMod's ReflectionHelper is now basically supporting everything Harmony's MethodInvoker does.

It's not as clear and took some time to figure out, but after benchmarking the results in MonoMod, it was visible that it's profitable: 

```
100000000 runs:
dmdNewBox (ReflectionHelper modified, immutable boxes): 36.5712269s
dmdMutable (ReflectionHelper, formerly called raw): 16.3218110s
dmdLocals (MethodInvoker): 46.7835971s

Calculated using ticks:
NewBox / Locals: 78.1710453384526%
Locals / NewBox: 127.924603754543%

NewBox / Mutable: 224.063536209309%
Mutable / NewBox: 44.6301980642602%

Locals / Mutable: 286.632390854177%
Mutable / Locals: 34.887892363454%
```

For backwards compatibility, I've set `directBoxValueAccess` to false by default. With it set to true, if passing a ValueType as `ref` argument, all other instances of the box are affected, too. While disabling this "safety" adds quite a performance boost when compared to the original local-using approach, I don't know if enabling raw box value access is feasible in Harmony.

It was interesting to see that there still was a slightly notable performance boost when cutting out locals and operating with the passed array directly.

I don't want to eat the cake alone, so take a piece :)