### PR TITLE
.NET Framework support

### DIFF
--- a/Harmony/ILCopying/Memory.cs
+++ b/Harmony/ILCopying/Memory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 
 namespace Harmony.ILCopying
 {
@@ -25,21 +26,23 @@ namespace Harmony.ILCopying
 
 		private readonly static FieldInfo f_DynamicMethod_m_method =
 			// .NET
-			typeof(DynamicMethod).GetField("m_method", BindingFlags.NonPublic | BindingFlags.Instance);
+			typeof(DynamicMethod).GetField("m_method", BindingFlags.NonPublic | BindingFlags.Instance) ??
+			// Mono
+			typeof(DynamicMethod).GetField("mhandle", BindingFlags.NonPublic | BindingFlags.Instance);
 		public static long GetMethodStart(MethodBase method)
 		{
 			RuntimeMethodHandle handle;
 
-			if (method is DynamicMethod)
-			{
-				if (f_DynamicMethod_m_method != null)
-					handle = (RuntimeMethodHandle) f_DynamicMethod_m_method.GetValue(method);
-				else
-					handle = method.MethodHandle;
-			}
+			if (method is DynamicMethod && f_DynamicMethod_m_method != null)
+				handle = (RuntimeMethodHandle) f_DynamicMethod_m_method.GetValue(method);
 			else
 				handle = method.MethodHandle;
 
+			/* Required to ensure that the method is already JITed and the method start doesn't change.
+			 * This seemingly only affects the .NET Framework.
+			 * - ade
+			 */
+			RuntimeHelpers.PrepareMethod(handle);
 			return handle.GetFunctionPointer().ToInt64();
 		}
 

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -75,7 +75,7 @@
     <ProjectReference Include="..\Harmony\Harmony.csproj">
       <Project>{69aee16a-b6e7-4642-8081-3928b32455df}</Project>
       <Name>Harmony</Name>
-      <Private>False</Private>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -28,6 +28,7 @@
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -1,11 +1,14 @@
 ﻿using Harmony;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace HarmonyTests.Assets
 {
 	public class Class1
 	{
+		// NoInlining required for .NET Framework
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void Method1()
 		{
 			Class1Patch.originalExecuted = true;

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -7,8 +7,6 @@ namespace HarmonyTests.Assets
 {
 	public class Class1
 	{
-		// NoInlining required for .NET Framework
-		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void Method1()
 		{
 			Class1Patch.originalExecuted = true;

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -1,4 +1,8 @@
-﻿namespace HarmonyTests.Assets
+﻿using Harmony;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace HarmonyTests.Assets
 {
 	public class Class1
 	{
@@ -23,6 +27,12 @@
 		public static void Postfix()
 		{
 			postfixed = true;
+		}
+
+		public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+		{
+			// no-op / passthrough
+			return instructions;
 		}
 
 		public static void _reset()

--- a/HarmonyTests/Patching/StaticPatches.cs
+++ b/HarmonyTests/Patching/StaticPatches.cs
@@ -8,17 +8,9 @@ namespace HarmonyTests
 	[TestClass]
 	public class StaticPatches
 	{
-		/*
 		[TestMethod]
 		public void TestMethod1()
 		{
-			// TODO: this test fails within VisualStudio when the patch tries to emit the
-			// call to the original method (the delegate to the copy of it).
-			//
-			// This actually works fine from within a Unity application and probably has
-			// something to do with the fact that VS does not allow .NET 2.0 targets to
-			// run unit tests. Or something else.
-
 			var originalClass = typeof(Class1);
 			Assert.IsNotNull(originalClass);
 			var originalMethod = originalClass.GetMethod("Method1");
@@ -27,31 +19,34 @@ namespace HarmonyTests
 			var patchClass = typeof(Class1Patch);
 			var realPrefix = patchClass.GetMethod("Prefix");
 			var realPostfix = patchClass.GetMethod("Postfix");
+			var realTranspiler = patchClass.GetMethod("Transpiler");
 			Assert.IsNotNull(realPrefix);
 			Assert.IsNotNull(realPostfix);
+			Assert.IsNotNull(realTranspiler);
 
 			Class1Patch._reset();
 
 			MethodInfo prefixMethod;
 			MethodInfo postfixMethod;
-			PatchTools.GetPatches(typeof(Class1Patch), originalMethod, out prefixMethod, out postfixMethod);
+			MethodInfo transpilerMethod;
+			PatchTools.GetPatches(typeof(Class1Patch), originalMethod, out prefixMethod, out postfixMethod, out transpilerMethod);
 
 			Assert.AreSame(realPrefix, prefixMethod);
 			Assert.AreSame(realPostfix, postfixMethod);
+			Assert.AreSame(realTranspiler, transpilerMethod);
 
 			var instance = HarmonyInstance.Create("test");
 			Assert.IsNotNull(instance);
 
-			var patcher = new Patcher(instance);
+			var patcher = new PatchProcessor(instance, originalMethod, new HarmonyMethod(prefixMethod), new HarmonyMethod(postfixMethod), new HarmonyMethod(transpilerMethod));
 			Assert.IsNotNull(patcher);
 
-			patcher.Patch(originalMethod, new HarmonyMethod(prefixMethod), new HarmonyMethod(postfixMethod));
+			patcher.Patch();
 			Class1.Method1();
 
 			Assert.IsTrue(Class1Patch.prefixed);
 			Assert.IsTrue(Class1Patch.originalExecuted);
 			Assert.IsTrue(Class1Patch.postfixed);
 		}
-		*/
 	}
 }


### PR DESCRIPTION
Relevant: #2 

`DynamicMethod::CreateDynMethod` doesn't exist in the .NET Framework; instead, `DynamicMethod::GetMethodDescriptor` and `RuntimeHelper::_CompileMethod` do.

As `_CompileMethod` seems to float around with different signatures (can take either the `RuntimeMethodHandle` or its `IntPtr` `Value` as only argument), `PrepareDynamicMethod` takes both variants into account.

I still need to get a test case mod running; @llaughlin, it'd be nice if you could help testing this as you seem to already have a test case :)

Notes:
* I'm currently manually reformatting the code to fit your existing code style.  
* All tests are failing locally without a copied `0Harmony.dll`, which is why I set
```xml
<Private>True</Private>
```
in `HarmonyTests.csproj`. Some tests are still failing, f.e. the `AccessCache_Method` test seems to fail due to an internal change in Harmony I guess?

I don't deem this PR to be complete until we get something detoured and running :)