### PR TITLE
Further .NET Framework support fixes

### DIFF
--- a/Harmony/ILCopying/Memory.cs
+++ b/Harmony/ILCopying/Memory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 
 namespace Harmony.ILCopying
 {
@@ -25,21 +26,23 @@ namespace Harmony.ILCopying
 
 		private readonly static FieldInfo f_DynamicMethod_m_method =
 			// .NET
-			typeof(DynamicMethod).GetField("m_method", BindingFlags.NonPublic | BindingFlags.Instance);
+			typeof(DynamicMethod).GetField("m_method", BindingFlags.NonPublic | BindingFlags.Instance) ??
+			// Mono
+			typeof(DynamicMethod).GetField("mhandle", BindingFlags.NonPublic | BindingFlags.Instance);
 		public static long GetMethodStart(MethodBase method)
 		{
 			RuntimeMethodHandle handle;
 
-			if (method is DynamicMethod)
-			{
-				if (f_DynamicMethod_m_method != null)
-					handle = (RuntimeMethodHandle) f_DynamicMethod_m_method.GetValue(method);
-				else
-					handle = method.MethodHandle;
-			}
+			if (method is DynamicMethod && f_DynamicMethod_m_method != null)
+				handle = (RuntimeMethodHandle) f_DynamicMethod_m_method.GetValue(method);
 			else
 				handle = method.MethodHandle;
 
+			/* Required to ensure that the method is already JITed and the method start doesn't change.
+			 * This seemingly only affects the .NET Framework.
+			 * - ade
+			 */
+			RuntimeHelpers.PrepareMethod(handle);
 			return handle.GetFunctionPointer().ToInt64();
 		}
 

--- a/Harmony/Tools/DynamicTools.cs
+++ b/Harmony/Tools/DynamicTools.cs
@@ -23,7 +23,7 @@ namespace Harmony
 
 			var method = new DynamicMethod(
 				patchName,
-				MethodAttributes.Public | (original.IsStatic ? MethodAttributes.Static : 0),
+				MethodAttributes.Public | MethodAttributes.Static,
 				CallingConventions.Standard,
 				AccessTools.GetReturnedType(original),
 				paramTypes,

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -28,6 +28,7 @@
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -43,4 +43,43 @@ namespace HarmonyTests.Assets
 			postfixed = false;
 		}
 	}
+
+	public class Class2
+	{
+		public void Method2()
+		{
+			Class2Patch.originalExecuted = true;
+		}
+	}
+
+	public class Class2Patch
+	{
+		public static bool prefixed = false;
+		public static bool originalExecuted = false;
+		public static bool postfixed = false;
+
+		public static bool Prefix()
+		{
+			prefixed = true;
+			return true;
+		}
+
+		public static void Postfix()
+		{
+			postfixed = true;
+		}
+
+		public static IEnumerable<CodeInstruction> Transpiler(MethodBase original, IEnumerable<CodeInstruction> instructions)
+		{
+			// no-op / passthrough
+			return instructions;
+		}
+
+		public static void _reset()
+		{
+			prefixed = false;
+			originalExecuted = false;
+			postfixed = false;
+		}
+	}
 }

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -1,11 +1,14 @@
 ﻿using Harmony;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace HarmonyTests.Assets
 {
 	public class Class1
 	{
+		// NoInlining required for .NET Framework
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void Method1()
 		{
 			Class1Patch.originalExecuted = true;

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -7,8 +7,6 @@ namespace HarmonyTests.Assets
 {
 	public class Class1
 	{
-		// NoInlining required for .NET Framework
-		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static void Method1()
 		{
 			Class1Patch.originalExecuted = true;

--- a/HarmonyTests/Patching/StaticPatches.cs
+++ b/HarmonyTests/Patching/StaticPatches.cs
@@ -61,5 +61,57 @@ namespace HarmonyTests
 			Assert.IsTrue(Class1Patch.originalExecuted);
 			Assert.IsTrue(Class1Patch.postfixed);
 		}
+
+		[TestMethod]
+		public void TestMethod2()
+		{
+			var originalClass = typeof(Class2);
+			Assert.IsNotNull(originalClass);
+			var originalMethod = originalClass.GetMethod("Method2");
+			Assert.IsNotNull(originalMethod);
+
+			var patchClass = typeof(Class2Patch);
+			var realPrefix = patchClass.GetMethod("Prefix");
+			var realPostfix = patchClass.GetMethod("Postfix");
+			var realTranspiler = patchClass.GetMethod("Transpiler");
+			Assert.IsNotNull(realPrefix);
+			Assert.IsNotNull(realPostfix);
+			Assert.IsNotNull(realTranspiler);
+
+			Class2Patch._reset();
+
+			MethodInfo prefixMethod;
+			MethodInfo postfixMethod;
+			MethodInfo transpilerMethod;
+			PatchTools.GetPatches(typeof(Class2Patch), originalMethod, out prefixMethod, out postfixMethod, out transpilerMethod);
+
+			Assert.AreSame(realPrefix, prefixMethod);
+			Assert.AreSame(realPostfix, postfixMethod);
+			Assert.AreSame(realTranspiler, transpilerMethod);
+
+			var instance = HarmonyInstance.Create("test");
+			Assert.IsNotNull(instance);
+
+			var patcher = new PatchProcessor(instance, originalMethod, new HarmonyMethod(prefixMethod), new HarmonyMethod(postfixMethod), new HarmonyMethod(transpilerMethod));
+			Assert.IsNotNull(patcher);
+
+			var originalMethodStartPre = Memory.GetMethodStart(originalMethod);
+			patcher.Patch();
+			var originalMethodStartPost = Memory.GetMethodStart(originalMethod);
+			Assert.AreEqual(originalMethodStartPre, originalMethodStartPost);
+			unsafe
+			{
+				byte patchedCode = *(byte*) originalMethodStartPre;
+				if (IntPtr.Size == sizeof(long))
+					Assert.IsTrue(patchedCode == 0x48);
+				else
+					Assert.IsTrue(patchedCode == 0x68);
+			}
+
+			new Class2().Method2();
+			Assert.IsTrue(Class2Patch.prefixed);
+			Assert.IsTrue(Class2Patch.originalExecuted);
+			Assert.IsTrue(Class2Patch.postfixed);
+		}
 	}
 }


### PR DESCRIPTION
Thanks to @Kittyfisto's work, Harmony is now functional on .NET Framework 4.6.2. I didn't notice the issues during the previous pull request.

Additionally, I've added a `TestMethod2` test case that tests patching instance methods. As @Kittyfisto noticed in #18, the .NET Framework is stricter and thus requires `DynamicMethod`s to always be static.

From my understanding, Harmony only cares about the target method's body (the method to jump into), not if the target `DynamicMethod` is static or not. Furthermore, I haven't noticed any issues with static methods mimicking instance method behavior. To me, it seems quite similar to how extension methods work.