### PR TITLE
Allow undoing patches partially and completely

### DIFF
--- a/Harmony/HarmonyInstance.cs
+++ b/Harmony/HarmonyInstance.cs
@@ -76,6 +76,12 @@ namespace Harmony
 			processor.Patch();
 		}
 
+		public void Restore(MethodBase original, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler = null)
+		{
+			var processor = new PatchProcessor(this, original, prefix, postfix, transpiler);
+			processor.Restore();
+		}
+
 		//
 
 		public Patches IsPatched(MethodBase method)

--- a/Harmony/Patch.cs
+++ b/Harmony/Patch.cs
@@ -85,23 +85,46 @@ namespace Harmony
 
 		public void AddPrefix(MethodInfo patch, string owner, int priority, string[] before, string[] after)
 		{
-			var l = prefixes.ToList();
-			l.Add(new Patch(patch, prefixes.Count() + 1, owner, priority, before, after));
-			prefixes = l.ToArray();
+			AddPatch(patch, ref prefixes, owner, priority, before, after);
 		}
 
 		public void AddPostfix(MethodInfo patch, string owner, int priority, string[] before, string[] after)
 		{
-			var l = postfixes.ToList();
-			l.Add(new Patch(patch, postfixes.Count() + 1, owner, priority, before, after));
-			postfixes = l.ToArray();
+			AddPatch(patch, ref postfixes, owner, priority, before, after);
 		}
 
 		public void AddTranspiler(MethodInfo patch, string owner, int priority, string[] before, string[] after)
 		{
-			var l = transpilers.ToList();
-			l.Add(new Patch(patch, transpilers.Count() + 1, owner, priority, before, after));
-			transpilers = l.ToArray();
+			AddPatch(patch, ref transpilers, owner, priority, before, after);
+		}
+
+		private void AddPatch(MethodInfo patch, ref Patch[] patchlist, string owner, int priority, string[] before, string[] after)
+		{
+			var l = patchlist.ToList();
+			l.Add(new Patch(patch, (patchlist.LastOrDefault()?.index ?? 0) + 1, owner, priority, before, after));
+			patchlist = l.ToArray();
+		}
+
+		public void RemovePrefix(MethodInfo patch)
+		{
+			RemovePatch(patch, ref prefixes);
+		}
+
+		public void RemovePostfix(MethodInfo patch)
+		{
+			RemovePatch(patch, ref postfixes);
+		}
+
+		public void RemoveTranspiler(MethodInfo patch)
+		{
+			RemovePatch(patch, ref transpilers);
+		}
+
+		private void RemovePatch(MethodInfo patch, ref Patch[] patchlist)
+		{
+			var l = patchlist.ToList();
+			l.RemoveAll(p => p.patch == patch);
+			patchlist = l.ToArray();
 		}
 	}
 

--- a/Harmony/PatchFunctions.cs
+++ b/Harmony/PatchFunctions.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
 
 namespace Harmony
 {
@@ -41,6 +43,27 @@ namespace Harmony
 			patchInfo.AddTranspiler(info.method, owner, priority, before, after);
 		}
 
+		public static void RemovePrefix(PatchInfo patchInfo, HarmonyMethod info)
+		{
+			if (info == null || info.method == null) return;
+
+			patchInfo.RemovePrefix(info.method);
+		}
+
+		public static void RemovePostfix(PatchInfo patchInfo, HarmonyMethod info)
+		{
+			if (info == null || info.method == null) return;
+
+			patchInfo.RemovePostfix(info.method);
+		}
+
+		public static void RemoveTranspiler(PatchInfo patchInfo, HarmonyMethod info)
+		{
+			if (info == null || info.method == null) return;
+
+			patchInfo.RemoveTranspiler(info.method);
+		}
+
 		public static List<MethodInfo> GetSortedPatchMethods(MethodBase original, Patch[] patches)
 		{
 			return patches
@@ -50,20 +73,46 @@ namespace Harmony
 				.ToList();
 		}
 
+		internal struct PatchHandle
+		{
+			public DynamicMethod PatchedMethod;
+			public byte[] OverwrittenCode;
+		}
+
 		public static void UpdateWrapper(MethodBase original, PatchInfo patchInfo)
 		{
 			var sortedPrefixes = GetSortedPatchMethods(original, patchInfo.prefixes);
 			var sortedPostfixes = GetSortedPatchMethods(original, patchInfo.postfixes);
 			var sortedTranspilers = GetSortedPatchMethods(original, patchInfo.transpilers);
 
+			var originalCodeStart = Memory.GetMethodStart(original);
+
+			// If we're overwriting an old patch, restore the original 12 (or 6) bytes of the method beforehand
+			object oldHandle;
+			if (PatchTools.RecallObject(original, out oldHandle))
+			{
+				var oldPatchHandle = (PatchHandle)oldHandle;
+				Memory.WriteBytes(originalCodeStart, oldPatchHandle.OverwrittenCode);
+			}
+
+			if (patchInfo.postfixes.Length + patchInfo.prefixes.Length + patchInfo.transpilers.Length == 0)
+			{
+				// No patches, can just leave the original method intact
+				PatchTools.ForgetObject(originalCodeStart);
+				return;
+			}
+
 			var replacement = MethodPatcher.CreatePatchedMethod(original, sortedPrefixes, sortedPostfixes, sortedTranspilers);
 			if (replacement == null) throw new MissingMethodException("Cannot create dynamic replacement for " + original);
-
-			var originalCodeStart = Memory.GetMethodStart(original);
 			var patchCodeStart = Memory.GetMethodStart(replacement);
-			Memory.WriteJump(originalCodeStart, patchCodeStart);
 
-			PatchTools.RememberObject(original, replacement); // no gc for new value + release old value to gc
+			// This part effectively corrupts the original compiled method, so we should prepare to restore the overwritten part later
+			// (It doesn't look like it breaks something, but... better safe than sorry?)
+			var oldBytes = new byte[(IntPtr.Size == sizeof(long)) ? 12 : 6];
+			Marshal.Copy((IntPtr)originalCodeStart, oldBytes, 0, oldBytes.Length);
+			// Store code being overwritten by the jump for the restoration
+			PatchTools.RememberObject(original, new PatchHandle { PatchedMethod = replacement, OverwrittenCode = oldBytes });
+			Memory.WriteJump(originalCodeStart, patchCodeStart);
 		}
 	}
 }

--- a/Harmony/PatchProcessor.cs
+++ b/Harmony/PatchProcessor.cs
@@ -66,6 +66,22 @@ namespace Harmony
 			}
 		}
 
+		public void Restore()
+		{
+			lock (locker)
+			{
+				var patchInfo = HarmonySharedState.GetPatchInfo(original);
+				if (patchInfo == null) return;
+
+				PatchFunctions.RemovePrefix(patchInfo, prefix);
+				PatchFunctions.RemovePostfix(patchInfo, postfix);
+				PatchFunctions.RemoveTranspiler(patchInfo, transpiler);
+				PatchFunctions.UpdateWrapper(original, patchInfo);
+
+				HarmonySharedState.UpdatePatchInfo(original, patchInfo);
+			}
+		}
+
 		bool CallPrepare()
 		{
 			if (original != null)

--- a/Harmony/Tools/PatchTools.cs
+++ b/Harmony/Tools/PatchTools.cs
@@ -14,6 +14,16 @@ namespace Harmony
 			objectReferences[key] = value;
 		}
 
+		public static void ForgetObject(object key)
+		{
+			objectReferences.Remove(key);
+		}
+
+		public static bool RecallObject(object key, out object value)
+		{
+			return objectReferences.TryGetValue(key, out value);
+		}
+
 		public static MethodInfo GetPatchMethod<T>(Type patchType, string name, Type[] parameters = null)
 		{
 			var method = patchType.GetMethods(AccessTools.all)

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -52,7 +52,15 @@ namespace HarmonyTests.Assets
 		}
 	}
 
-	public class Class2Patch
+    public class RestoreableClass
+    {
+        public void Method2()
+		{
+			Class2Patch.originalExecuted = true;
+        }
+    }
+
+    public class Class2Patch
 	{
 		public static bool prefixed = false;
 		public static bool originalExecuted = false;


### PR DESCRIPTION
As described in #11. Since implementing it looked pretty straightforward, here you go. HarmonyInstance now has Restore method, mirroring Patch signature.
Basic tests are included.

I have a question, however: when patching the original method, what is being overwritten by the jump instruction, exactly? I took care of restoring the overwritten part, but it doesn't seem to affect the execution either way, why?