### PR TITLE
Added HarmonyPatchAll and HarmonyMethodFilter Attributes.

### DIFF
--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace Harmony
 {
@@ -55,7 +56,21 @@ namespace Harmony
 		}
 	}
 
-	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Class)]
+    public class HarmonyPatchAll  : HarmonyAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class HarmonyMethodFilter : HarmonyAttribute
+    {
+        public HarmonyMethodFilter(BindingFlags flags)
+        {
+            info.patchAllFlags = flags;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 	public class HarmonyPriority : HarmonyAttribute
 	{
 		public HarmonyPriority(int prioritiy)

--- a/Harmony/HarmonyInstance.cs
+++ b/Harmony/HarmonyInstance.cs
@@ -72,7 +72,7 @@ namespace Harmony
 
 		public void Patch(MethodBase original, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler = null)
 		{
-			var processor = new PatchProcessor(this, original, prefix, postfix, transpiler);
+			var processor = new PatchProcessor(this, new List<MethodBase> { original }, prefix, postfix, transpiler);
 			processor.Patch();
 		}
 

--- a/Harmony/HarmonyMethod.cs
+++ b/Harmony/HarmonyMethod.cs
@@ -14,7 +14,8 @@ namespace Harmony
 		public string methodName;
 		public Type[] parameter;
 		public int prioritiy = -1;
-		public string[] before;
+        public BindingFlags patchAllFlags = BindingFlags.Default;
+        public string[] before;
 		public string[] after;
 
 		public HarmonyMethod()

--- a/Harmony/MethodPatcher.cs
+++ b/Harmony/MethodPatcher.cs
@@ -103,8 +103,9 @@ namespace Harmony
 			{
 				if (patchParam.Name == INSTANCE_PARAM)
 				{
-					if (!isInstance) throw new Exception("Cannot get instance from static method " + original);
-					if (patchParam.ParameterType.IsByRef)
+                    if (!isInstance)
+                        Emitter.Emit(il, OpCodes.Ldnull);
+					else if (patchParam.ParameterType.IsByRef)
 						Emitter.Emit(il, OpCodes.Ldarga, 0); // probably won't work or will be useless
 					else
 						Emitter.Emit(il, OpCodes.Ldarg_0);

--- a/Harmony/PatchProcessor.cs
+++ b/Harmony/PatchProcessor.cs
@@ -1,156 +1,185 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Harmony
 {
-	public class PatchProcessor
-	{
-		static object locker = new object();
+    public class PatchProcessor
+    {
+        static object locker = new object();
 
-		readonly HarmonyInstance instance;
+        readonly HarmonyInstance instance;
 
-		readonly Type container;
-		readonly HarmonyMethod containerAttributes;
+        readonly Type container;
+        readonly HarmonyMethod containerAttributes;
 
-		MethodBase original;
-		HarmonyMethod prefix;
-		HarmonyMethod postfix;
-		HarmonyMethod transpiler;
+        List<MethodBase> originals;
+        HarmonyMethod prefix;
+        HarmonyMethod postfix;
+        HarmonyMethod transpiler;
+        BindingFlags patchAllFlags;
 
-		public PatchProcessor(HarmonyInstance instance, Type type, HarmonyMethod attributes)
-		{
-			this.instance = instance;
-			container = type;
-			containerAttributes = attributes ?? new HarmonyMethod(null);
-			prefix = containerAttributes.Clone();
-			postfix = containerAttributes.Clone();
-			transpiler = containerAttributes.Clone();
-			ProcessType();
-		}
+        public PatchProcessor(HarmonyInstance instance, Type type, HarmonyMethod attributes)
+        {
+            this.instance = instance;
+            container = type;
+            containerAttributes = attributes ?? new HarmonyMethod(null);
+            patchAllFlags = attributes.patchAllFlags;
+            prefix = containerAttributes.Clone();
+            postfix = containerAttributes.Clone();
+            transpiler = containerAttributes.Clone();
+            ProcessType();
+        }
 
-		public PatchProcessor(HarmonyInstance instance, MethodBase original, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler)
-		{
-			this.instance = instance;
-			this.original = original;
-			this.prefix = prefix ?? new HarmonyMethod(null);
-			this.postfix = postfix ?? new HarmonyMethod(null);
-			this.transpiler = transpiler ?? new HarmonyMethod(null);
-		}
+        public PatchProcessor(HarmonyInstance instance, List<MethodBase> originals, HarmonyMethod prefix, HarmonyMethod postfix, HarmonyMethod transpiler)
+        {
+            this.instance = instance;
+            this.originals = originals;
+            this.prefix = prefix ?? new HarmonyMethod(null);
+            this.postfix = postfix ?? new HarmonyMethod(null);
+            this.transpiler = transpiler ?? new HarmonyMethod(null);
+        }
 
-		public static Patches IsPatched(MethodBase method)
-		{
-			var patchInfo = HarmonySharedState.GetPatchInfo(method);
-			if (patchInfo == null) return null;
-			return new Patches(patchInfo.prefixes, patchInfo.postfixes, patchInfo.transpilers);
-		}
+        public static Patches IsPatched(MethodBase method)
+        {
+            var patchInfo = HarmonySharedState.GetPatchInfo(method);
+            if (patchInfo == null) return null;
+            return new Patches(patchInfo.prefixes, patchInfo.postfixes, patchInfo.transpilers);
+        }
 
-		public static IEnumerable<MethodBase> AllPatchedMethods()
-		{
-			return HarmonySharedState.GetPatchedMethods();
-		}
+        public static IEnumerable<MethodBase> AllPatchedMethods()
+        {
+            return HarmonySharedState.GetPatchedMethods();
+        }
 
-		public void Patch()
-		{
-			lock (locker)
-			{
-				var patchInfo = HarmonySharedState.GetPatchInfo(original);
-				if (patchInfo == null) patchInfo = new PatchInfo();
+        public void Patch()
+        {
+            lock (locker)
+            {
+                foreach (var original in originals)
+                {
+                    if (original == null)
+                        throw new Exception();
+                    var patchInfo = HarmonySharedState.GetPatchInfo(original);
+                    if (patchInfo == null) patchInfo = new PatchInfo();
 
-				PatchFunctions.AddPrefix(patchInfo, instance.Id, prefix);
-				PatchFunctions.AddPostfix(patchInfo, instance.Id, postfix);
-				PatchFunctions.AddTranspiler(patchInfo, instance.Id, transpiler);
-				PatchFunctions.UpdateWrapper(original, patchInfo);
+                    PatchFunctions.AddPrefix(patchInfo, instance.Id, prefix);
+                    PatchFunctions.AddPostfix(patchInfo, instance.Id, postfix);
+                    PatchFunctions.AddTranspiler(patchInfo, instance.Id, transpiler);
+                    PatchFunctions.UpdateWrapper(original, patchInfo);
 
-				HarmonySharedState.UpdatePatchInfo(original, patchInfo);
-			}
-		}
+                    HarmonySharedState.UpdatePatchInfo(original, patchInfo);
+                }
+            }
+        }
 
-		bool CallPrepare()
-		{
-			if (original != null)
-				return RunMethod<HarmonyPrepare, bool>(true, original);
-			return RunMethod<HarmonyPrepare, bool>(true);
-		}
+        bool CallPrepare()
+        {
+            if (originals != null && originals.Count > 0)
+                return RunMethod<HarmonyPrepare, bool>(true, originals.First());
+            return RunMethod<HarmonyPrepare, bool>(true);
+        }
 
-		void ProcessType()
-		{
-			original = GetOriginalMethod();
+        void ProcessType()
+        {
+            // Grab all methods with non-empty method bodys if the PatchAll attribute is specified
+            bool isPatchAll = Attribute.GetCustomAttribute(container, typeof(HarmonyPatchAll)) != null;
+            if (isPatchAll)
+            {
+                if (containerAttributes.originalType != null)
+                    if (patchAllFlags != BindingFlags.Default) //BindingFlags.Default causes GetMethods to return null.
+                        originals = (new List<MethodBase>(containerAttributes.originalType.GetMethods(patchAllFlags)))
+                            .Where(mb => mb.GetMethodBody() != null).ToList();
+                    else
+                        originals = (new List<MethodBase>(containerAttributes.originalType.GetMethods()))
+                            .Where(mb => mb.GetMethodBody() != null).ToList();
+                else
+                    throw new ArgumentException("Target object type must be specified for class " + container.FullName);
+            }
+            else
+            {
+                originals = new List<MethodBase>();
+                originals.Add(GetOriginalMethod());
+            }
 
-			var patchable = CallPrepare();
-			if (patchable)
-			{
-				if (original == null)
-					original = RunMethod<HarmonyTargetMethod, MethodBase>(null);
-				if (original == null)
-					throw new ArgumentException("No target method specified for class " + container.FullName);
+            var patchable = CallPrepare();
+            if (patchable)
+            {
+                if (originals.Count <= 0)
+                    originals.Add(RunMethod<HarmonyTargetMethod, MethodBase>(null));
+                if (originals.Count <= 0)
+                    throw new ArgumentException("No target method specified for class " + container.FullName);
 
-				PatchTools.GetPatches(container, original, out prefix.method, out postfix.method, out transpiler.method);
+                PatchTools.GetPatches(container, out prefix.method, out postfix.method, out transpiler.method);
 
-				if (prefix.method != null)
-				{
-					if (prefix.method.IsStatic == false)
-						throw new ArgumentException("Patch method " + prefix.method.Name + " in " + prefix.method.DeclaringType + " must be static");
+                if (prefix.method != null)
+                {
+                    if (prefix.method.IsStatic == false)
+                        throw new ArgumentException("Patch method " + prefix.method.Name + " in " + prefix.method.DeclaringType + " must be static");
 
-					var prefixAttributes = prefix.method.GetHarmonyMethods();
-					containerAttributes.Merge(HarmonyMethod.Merge(prefixAttributes)).CopyTo(prefix);
-				}
+                    var prefixAttributes = prefix.method.GetHarmonyMethods();
+                    containerAttributes.Merge(HarmonyMethod.Merge(prefixAttributes)).CopyTo(prefix);
+                }
 
-				if (postfix.method != null)
-				{
-					if (postfix.method.IsStatic == false)
-						throw new ArgumentException("Patch method " + postfix.method.Name + " in " + postfix.method.DeclaringType + " must be static");
+                if (postfix.method != null)
+                {
+                    if (postfix.method.IsStatic == false)
+                        throw new ArgumentException("Patch method " + postfix.method.Name + " in " + postfix.method.DeclaringType + " must be static");
 
-					var postfixAttributes = postfix.method.GetHarmonyMethods();
-					containerAttributes.Merge(HarmonyMethod.Merge(postfixAttributes)).CopyTo(postfix);
-				}
+                    var postfixAttributes = postfix.method.GetHarmonyMethods();
+                    containerAttributes.Merge(HarmonyMethod.Merge(postfixAttributes)).CopyTo(postfix);
+                }
 
-				if (transpiler.method != null)
-				{
-					if (transpiler.method.IsStatic == false)
-						throw new ArgumentException("Patch method " + transpiler.method.Name + " in " + transpiler.method.DeclaringType + " must be static");
+                if (transpiler.method != null)
+                {
+                    if (isPatchAll)
+                        throw new ArgumentException("Patch method " + transpiler.method.Name + " in " + transpiler.method.DeclaringType +
+                            " cannot be used with HarmonyPatchAll because it is a transpiler patch");
+                    if (transpiler.method.IsStatic == false)
+                        throw new ArgumentException("Patch method " + transpiler.method.Name + " in " + transpiler.method.DeclaringType + " must be static");
 
-					var infixAttributes = transpiler.method.GetHarmonyMethods();
-					containerAttributes.Merge(HarmonyMethod.Merge(infixAttributes)).CopyTo(transpiler);
-				}
-			}
-		}
+                    var infixAttributes = transpiler.method.GetHarmonyMethods();
+                    containerAttributes.Merge(HarmonyMethod.Merge(infixAttributes)).CopyTo(transpiler);
+                }
+            }
+        }
 
-		MethodBase GetOriginalMethod()
-		{
-			var attr = containerAttributes;
-			if (attr.originalType == null) return null;
-			if (attr.methodName == null)
-				return AccessTools.Constructor(attr.originalType, attr.parameter);
-			return AccessTools.Method(attr.originalType, attr.methodName, attr.parameter);
-		}
+        MethodBase GetOriginalMethod()
+        {
+            var attr = containerAttributes;
+            if (attr.originalType == null) return null;
+            if (attr.methodName == null)
+                return AccessTools.Constructor(attr.originalType, attr.parameter);
+            return AccessTools.Method(attr.originalType, attr.methodName, attr.parameter);
+        }
 
-		T RunMethod<S, T>(T defaultIfNotExisting, params object[] parameters)
-		{
-			var methodName = typeof(S).Name.Replace("Harmony", "");
+        T RunMethod<S, T>(T defaultIfNotExisting, params object[] parameters)
+        {
+            var methodName = typeof(S).Name.Replace("Harmony", "");
 
-			var paramList = new List<object> { instance };
-			paramList.AddRange(parameters);
-			var paramTypes = AccessTools.GetTypes(paramList.ToArray());
-			var method = PatchTools.GetPatchMethod<S>(container, methodName, paramTypes);
-			if (method != null && typeof(T).IsAssignableFrom(method.ReturnType))
-				return (T)method.Invoke(null, paramList.ToArray());
+            var paramList = new List<object> { instance };
+            paramList.AddRange(parameters);
+            var paramTypes = AccessTools.GetTypes(paramList.ToArray());
+            var method = PatchTools.GetPatchMethod<S>(container, methodName, paramTypes);
+            if (method != null && typeof(T).IsAssignableFrom(method.ReturnType))
+                return (T)method.Invoke(null, paramList.ToArray());
 
-			method = PatchTools.GetPatchMethod<S>(container, methodName, new Type[] { typeof(HarmonyInstance) });
-			if (method != null && typeof(T).IsAssignableFrom(method.ReturnType))
-				return (T)method.Invoke(null, new object[] { instance });
+            method = PatchTools.GetPatchMethod<S>(container, methodName, new Type[] { typeof(HarmonyInstance) });
+            if (method != null && typeof(T).IsAssignableFrom(method.ReturnType))
+                return (T)method.Invoke(null, new object[] { instance });
 
-			method = PatchTools.GetPatchMethod<S>(container, methodName, Type.EmptyTypes);
-			if (method != null)
-			{
-				if (typeof(T).IsAssignableFrom(method.ReturnType))
-					return (T)method.Invoke(null, Type.EmptyTypes);
+            method = PatchTools.GetPatchMethod<S>(container, methodName, Type.EmptyTypes);
+            if (method != null)
+            {
+                if (typeof(T).IsAssignableFrom(method.ReturnType))
+                    return (T)method.Invoke(null, Type.EmptyTypes);
 
-				method.Invoke(null, Type.EmptyTypes);
-				return defaultIfNotExisting;
-			}
+                method.Invoke(null, Type.EmptyTypes);
+                return defaultIfNotExisting;
+            }
 
-			return defaultIfNotExisting;
-		}
-	}
+            return defaultIfNotExisting;
+        }
+    }
 }

--- a/Harmony/Tools/PatchTools.cs
+++ b/Harmony/Tools/PatchTools.cs
@@ -23,11 +23,8 @@ namespace Harmony
 			return method;
 		}
 
-		public static void GetPatches(Type patchType, MethodBase original, out MethodInfo prefix, out MethodInfo postfix, out MethodInfo transpiler)
+		public static void GetPatches(Type patchType, out MethodInfo prefix, out MethodInfo postfix, out MethodInfo transpiler)
 		{
-			var type = original.DeclaringType;
-			var methodName = original.Name;
-
 			prefix = GetPatchMethod<HarmonyPrefix>(patchType, "Prefix");
 			postfix = GetPatchMethod<HarmonyPostfix>(patchType, "Postfix");
 			transpiler = GetPatchMethod<HarmonyTranspiler>(patchType, "Transpiler");


### PR DESCRIPTION
Usages:

```
[HarmonyPatchAll]
class RandomPatch
{
        [HarmonyPrefix]
        public static bool prefixAll(PathFinder __instance, object __state)
        { ...}
        [HarmonyPostFix]
        public static bool postfixAll(PathFinder __instance, object __state)        
        {...}
}

[HarmonyPatchAll]
[HarmonyMethodFilter(BindingFlags.Instance | BindingFlags.Public)]
class AnotherRandomPatch
{...}
```

I did not implement a Type[] parameter, as it seemed that if you needed the parameters of the function you were accessing you should be implementing individual patches. __instance and __state work, but __result requires an explicit type and has been left unsupported. Finally, transpilers defined in a HarmonyPatchAll will throw an exception.