### PR TITLE
Added ability to give parameters your own name

### DIFF
--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -116,17 +116,17 @@ namespace Harmony
 	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
 	public class HarmonyParameter : Attribute
 	{
-		public string Name { get; private set; }
-		public string CustomName { get; private set; }
+		public string OriginalName { get; private set; }
+		public string NewName { get; private set; }
 
-		public HarmonyParameter(string name) : this(name, null)
+		public HarmonyParameter(string originalName) : this(originalName, null)
 		{
 		}
 
-		public HarmonyParameter(string name, string customName)
+		public HarmonyParameter(string originalName, string newName)
 		{
-			Name = name;
-			CustomName = customName;
+			OriginalName = originalName;
+			NewName = newName;
 		}
 	}
 }

--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -113,7 +113,7 @@ namespace Harmony
 	// If you want to rename parameter name in case it's obfuscated or something else 
 	// you can use the following attribute:
 
-	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method | AttributeTargets.Class)]
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
 	public class HarmonyParameter : Attribute
 	{
 		public string Name { get; private set; }

--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -113,19 +113,19 @@ namespace Harmony
 	// If you want to rename parameter name in case it's obfuscated or something else 
 	// you can use the following attribute:
 
-	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method | AttributeTargets.Class)]
 	public class HarmonyParameter : Attribute
 	{
 		public string Name { get; private set; }
 		public string CustomName { get; private set; }
 
-		public HarmonyParameter(string name)
+		public HarmonyParameter(string name) : this(name, null)
 		{
-			Name = name;
 		}
 
-		public HarmonyParameter(string name, string customName) : this(name)
+		public HarmonyParameter(string name, string customName)
 		{
+			Name = name;
 			CustomName = customName;
 		}
 	}

--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -109,4 +109,18 @@ namespace Harmony
 	public class HarmonyTranspiler : Attribute
 	{
 	}
+
+	// If you want to rename parameter name in case it's obfuscated or something else 
+	// you can use the following attribute:
+
+	[AttributeUsage(AttributeTargets.Parameter)]
+	public class HarmonyParameter : Attribute
+	{
+		public string name;
+
+		public HarmonyParameter(string name)
+		{
+			this.name = name;
+		}
+	}
 }

--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -113,14 +113,20 @@ namespace Harmony
 	// If you want to rename parameter name in case it's obfuscated or something else 
 	// you can use the following attribute:
 
-	[AttributeUsage(AttributeTargets.Parameter)]
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
 	public class HarmonyParameter : Attribute
 	{
-		public string name;
+		public string Name { get; private set; }
+		public string CustomName { get; private set; }
 
 		public HarmonyParameter(string name)
 		{
-			this.name = name;
+			Name = name;
+		}
+
+		public HarmonyParameter(string name, string customName) : this(name)
+		{
+			CustomName = customName;
 		}
 	}
 }

--- a/Harmony/MethodPatcher.cs
+++ b/Harmony/MethodPatcher.cs
@@ -112,8 +112,8 @@ namespace Harmony
 		static string GetParameterOverride(this ParameterInfo parameter)
 		{
 			var paramAttr = parameter.GetParameterAttribute();
-			if (paramAttr != null && !string.IsNullOrEmpty(paramAttr.Name))
-				return paramAttr.Name;
+			if (paramAttr != null && !string.IsNullOrEmpty(paramAttr.OriginalName))
+				return paramAttr.OriginalName;
 
 			return null;
 		}
@@ -122,9 +122,9 @@ namespace Harmony
 		{
 			if (patchAttributes.Length > 0)
 			{
-				var paramAttr = patchAttributes.SingleOrDefault(p => p.CustomName == name);
-				if (paramAttr != null && !string.IsNullOrEmpty(paramAttr.Name))
-					return paramAttr.Name;
+				var paramAttr = patchAttributes.SingleOrDefault(p => p.NewName == name);
+				if (paramAttr != null && !string.IsNullOrEmpty(paramAttr.OriginalName))
+					return paramAttr.OriginalName;
 			}
 
 			return null;
@@ -174,16 +174,16 @@ namespace Harmony
 
 				string patchParamName = patchParam.Name;
 
-				var customName = patchParam.GetParameterOverride();
-				if (customName != null)
+				var originalName = patchParam.GetParameterOverride();
+				if (originalName != null)
 				{
-					patchParamName = customName;
+					patchParamName = originalName;
 				}
 				else
 				{
-					customName = patch.GetParameterOverride(patchParamName, true);
-					if (customName != null)
-						patchParamName = customName;
+					originalName = patch.GetParameterOverride(patchParamName, true);
+					if (originalName != null)
+						patchParamName = originalName;
 				}
 
 				var idx = Array.IndexOf(originalParameterNames, patchParamName);

--- a/Harmony/MethodPatcher.cs
+++ b/Harmony/MethodPatcher.cs
@@ -127,7 +127,9 @@ namespace Harmony
 					continue;
 				}
 
-				var idx = Array.IndexOf(originalParameterNames, patchParam.Name);
+				var paramAttr = patchParam.GetCustomAttributes(false).FirstOrDefault(attr => attr is HarmonyParameter) as HarmonyParameter;
+				var patchParamName = paramAttr != null ? paramAttr.name : patchParam.Name;
+				var idx = Array.IndexOf(originalParameterNames, patchParamName);
 				if (idx == -1) throw new Exception("Parameter \"" + patchParam.Name + "\" not found in method " + original);
 
 				//   original -> patch     opcode


### PR DESCRIPTION
Fixes #51 

First I wanted to add a new field to PatchInfo/Patch but I changed my mind. If you have any design/optimization suggestions or you have any objections regarding current design tell me. Feel free to change the naming as well. I tried to follow your naming convention.

```csharp
[HarmonyPatch(typeof(Player))]
[HarmonyPatch("CastSpell")]
[HarmonyParameter("#d", "spellId")]
class ExamplePatch
{
    // This has the higher priority than the one above
    [HarmonyParameter("#d", "spellId")]
    [HarmonyParameter("#c", "targetid")]
    // Parameter attributes have the highest priority
    public static void Prefix([HarmonyParameter("#d")] int spellId, int targetid)
    {
    }
    
    // No need to do anything since we have added class-wide attribute
    public static void Postfix(int spellId)
    {
    }
}
```

This also works when you use `Harmony.Patch` instead of `Harmony.PatchAll`