### PR TITLE
Add convenient accessor class

### DIFF
--- a/Harmony/Tools/Accessor.cs
+++ b/Harmony/Tools/Accessor.cs
@@ -1,0 +1,57 @@
+using Harmony;
+using System;
+
+namespace Harmony
+{
+	public class Reference<T>
+	{
+		private Traverse traverse;
+
+		public Reference(Traverse traverse)
+		{
+			this.traverse = traverse;
+		}
+
+		public T Value
+		{
+			get { return traverse.GetValue<T>(); }
+			set { traverse.SetValue(value); }
+		}
+	}
+
+	public class Accessor
+	{
+		private Traverse traverse;
+
+		public Accessor(object instance)
+		{
+			traverse = new Traverse(instance);
+		}
+
+		public Accessor(Type type)
+		{
+			traverse = new Traverse(type);
+		}
+
+		public static Accessor ForInstance(object instance)
+		{
+			return new Accessor(instance);
+		}
+
+		public static Accessor ForType(Type type)
+		{
+			return new Accessor(type);
+		}
+
+		public Reference<T> Field<T>(string fieldName)
+		{
+			return new Reference<T>(traverse.Field(fieldName));
+		}
+
+		public Reference<T> Property<T>(string propertyName)
+		{
+			return new Reference<T>(traverse.Property(propertyName));
+		}
+	}
+
+}


### PR DESCRIPTION
Something what was proposed here: https://github.com/pardeike/Harmony/issues/20#issuecomment-311988446

Basically it's a nice looking helper(under the hood using`Traverse`) for accessing/modifying field and property values. 

Example:

```csharp
var accessor = Accessor.ForInstance(someinstance);
var fieldValue = accessor.Field<int>("_someIntField").Value;
var propertyValue = accessor.Property<int>("SomeIntProperty").Value;

var healthFieldReference = accessor.Field<int>("_health");
// Modifying values is possible too
healthFieldReference.Value = 999;

```