### PR TITLE
Fix issue formatting ldstr operand

### DIFF
--- a/Harmony/CodeInstruction.cs
+++ b/Harmony/CodeInstruction.cs
@@ -56,7 +56,7 @@ namespace Harmony
 			var extras = list.Count > 0 ? " [" + string.Join(", ", list.ToArray()) + "]" : "";
 			var operandStr = Emitter.FormatArgument(operand);
 			if (operandStr != "") operandStr = " " + operandStr;
-			return string.Format(opcode + operandStr + extras);
+			return opcode + operandStr + extras;
 		}
 	}
 }

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="Extras\Assets\MethodInvokerClasses.cs" />
     <Compile Include="Extras\TestMethodInvoker.cs" />
+    <Compile Include="IL\Instructions.cs" />
     <Compile Include="Patching\Assets\PatchClasses.cs" />
     <Compile Include="Patching\StaticPatches.cs" />
     <Compile Include="Patching\Transpiling.cs" />

--- a/HarmonyTests/IL/Instructions.cs
+++ b/HarmonyTests/IL/Instructions.cs
@@ -1,0 +1,18 @@
+using Harmony;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection.Emit;
+
+namespace HarmonyTests.IL
+{
+	[TestClass]
+   public class Instructions
+   {
+		[TestMethod]
+		public void TestMalformedStringOperand()
+	   {
+			string expectedOperand = "this should not fail {4}";
+			var inst = new CodeInstruction(OpCodes.Ldstr, expectedOperand);
+			Assert.AreEqual($"ldstr \"{expectedOperand}\"", inst.ToString());
+	   }
+   }
+}


### PR DESCRIPTION
Previously if you were to call ToString on a `ldstr` instruction with a constant string that included format indices like `{1}`, then it would get passed directly to `string.Format`, causing an exception.

This PR removes the seemingly unnecessary `string.Format` call (as no other parameters are passed) and includes a test to cover `ToString()` exceptions.