### PR TITLE
Add param array parameters to HarmonyPatchAttribute

### DIFF
--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -24,34 +24,27 @@ namespace Harmony
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 	public class HarmonyPatch : HarmonyAttribute
 	{
-
-		public HarmonyPatch()
-		: this(null, (string) null, null)
+		public HarmonyPatch() : this(null, (string)null, null)
 		{
 		}
 
-	  public HarmonyPatch(Type type)
-			: this(type, (string) null, null)
+		public HarmonyPatch(Type type) : this(type, (string)null, null)
 		{
 		}
 
-		public HarmonyPatch(string methodName)
-			: this(null, methodName, null)
+		public HarmonyPatch(string methodName) : this(null, methodName, null)
 		{
 		}
 
-		public HarmonyPatch(params Type[] parameter)
-			: this(null, null, parameter)
+		public HarmonyPatch(params Type[] parameter) : this(null, null, parameter)
 		{
 		}
 
-	  public HarmonyPatch(string propertyName, PropertyMethod type)
-			: this(null, (type == PropertyMethod.Getter ? "get_" : "set_") + propertyName, null)
+		public HarmonyPatch(string propertyName, PropertyMethod type) : this(null, (type == PropertyMethod.Getter ? "get_" : "set_") + propertyName, null)
 		{
 		}
 
-		public HarmonyPatch(Type type, params Type[] parameter)
-			: this(type, null, parameter)
+		public HarmonyPatch(Type type, params Type[] parameter) : this(type, null, parameter)
 		{
 		}
 
@@ -61,7 +54,6 @@ namespace Harmony
 			info.methodName = methodName;
 			info.parameter = parameter;
 		}
-
 	}
 
 	[AttributeUsage(AttributeTargets.Class)]
@@ -138,19 +130,32 @@ namespace Harmony
 	}
 
 	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-	public class HarmonyParameter : Attribute
+	public class HarmonyArgument : Attribute
 	{
 		public string OriginalName { get; private set; }
+		public int Index { get; private set; }
 		public string NewName { get; private set; }
 
-		public HarmonyParameter(string originalName) : this(originalName, null)
+		public HarmonyArgument(string originalName) : this(originalName, null)
 		{
 		}
 
-		public HarmonyParameter(string originalName, string newName)
+		public HarmonyArgument(int index) : this(index, null)
+		{
+		}
+
+		public HarmonyArgument(string originalName, string newName)
 		{
 			OriginalName = originalName;
+			Index = -1;
 			NewName = newName;
+		}
+
+		public HarmonyArgument(int index, string name)
+		{
+			OriginalName = null;
+			Index = index;
+			NewName = name;
 		}
 	}
 

--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -24,43 +24,44 @@ namespace Harmony
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 	public class HarmonyPatch : HarmonyAttribute
 	{
+
 		public HarmonyPatch()
+		: this(null, (string) null, null)
 		{
 		}
 
-		public HarmonyPatch(Type type)
+	  public HarmonyPatch(Type type)
+			: this(type, (string) null, null)
 		{
-			info.originalType = type;
 		}
 
 		public HarmonyPatch(string methodName)
+			: this(null, methodName, null)
 		{
-			info.methodName = methodName;
 		}
 
-		public HarmonyPatch(string propertyName, PropertyMethod type)
+		public HarmonyPatch(params Type[] parameter)
+			: this(null, null, parameter)
 		{
-			var prefix = type == PropertyMethod.Getter ? "get_" : "set_";
-			info.methodName = prefix + propertyName;
 		}
 
-		public HarmonyPatch(Type[] parameter)
+	  public HarmonyPatch(string propertyName, PropertyMethod type)
+			: this(null, (type == PropertyMethod.Getter ? "get_" : "set_") + propertyName, null)
 		{
-			info.parameter = parameter;
 		}
 
-		public HarmonyPatch(Type type, string methodName, Type[] parameter = null)
+		public HarmonyPatch(Type type, params Type[] parameter)
+			: this(type, null, parameter)
+		{
+		}
+
+		public HarmonyPatch(Type type, string methodName, params Type[] parameter)
 		{
 			info.originalType = type;
 			info.methodName = methodName;
 			info.parameter = parameter;
 		}
 
-		public HarmonyPatch(Type type, Type[] parameter = null)
-		{
-			info.originalType = type;
-			info.parameter = parameter;
-		}
 	}
 
 	[AttributeUsage(AttributeTargets.Class)]

--- a/Harmony/Extras/MethodInvoker.cs
+++ b/Harmony/Extras/MethodInvoker.cs
@@ -22,7 +22,7 @@ namespace Harmony
 
 		static FastInvokeHandler Handler(MethodInfo methodInfo, Module module, bool directBoxValueAccess = false)
 		{
-			var dynamicMethod = new DynamicMethod("FastInvoke_" + methodInfo.Name + "_" + (directBoxValueAccess ? "direct" : "indirect"), typeof(object), new Type[] { typeof(object), typeof(object[]) }, module);
+			var dynamicMethod = new DynamicMethod("FastInvoke_" + methodInfo.Name + "_" + (directBoxValueAccess ? "direct" : "indirect"), typeof(object), new Type[] { typeof(object), typeof(object[]) }, module, true);
 			var il = dynamicMethod.GetILGenerator();
 
 			if (!methodInfo.IsStatic)

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -10,13 +10,15 @@
 		<Authors>Andreas Pardeike</Authors>
 		<AssemblyName>0Harmony</AssemblyName>
 		<SignAssembly>false</SignAssembly>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<PackageLicenseUrl>https://raw.githubusercontent.com/pardeike/Harmony/master/LICENSE</PackageLicenseUrl>
 		<PackageProjectUrl>https://github.com/pardeike/Harmony</PackageProjectUrl>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageTags>Harmony,Mono,Patch,Patching,Runtime,Detour,Detours,Aspect,Aspects</PackageTags>
 		<Configurations>Debug-3.5;Release-3.5;Debug-4.7.1;Release-4.7.1</Configurations>
 		<TargetFrameworks>net35;net471</TargetFrameworks>
+		<AssemblyVersion>1.1.1.0</AssemblyVersion>
+		<FileVersion>1.1.1.0</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Harmony/Tools/PatchTools.cs
+++ b/Harmony/Tools/PatchTools.cs
@@ -17,7 +17,7 @@ namespace Harmony
 		public static MethodInfo GetPatchMethod<T>(Type patchType, string name, Type[] parameters = null)
 		{
 			var method = patchType.GetMethods(AccessTools.all)
-				.FirstOrDefault(m => m.GetCustomAttributes(typeof(T), true).Count() > 0);
+				.FirstOrDefault(m => m.GetCustomAttributes(typeof(T), true).Any());
 			if (method == null)
 				method = AccessTools.Method(patchType, name, parameters);
 			return method;


### PR DESCRIPTION
Okay, this version should actually work.

I've changed the signatures _and_ redirected the constructors to a shared case to ensure correct parameters are always passed.

Note: **Every** variant with a `param` array needs an overload _without_ that parameter, so `HarmonyPatch()` like calls actually resolve to the `null`version of the overload instead of the 'empty array' version.

---

Closes #96 