### PR TITLE
Improved Exception Throwing from HarmonyMethod & MethodPatcher

### DIFF
--- a/Harmony/HarmonyMethod.cs
+++ b/Harmony/HarmonyMethod.cs
@@ -41,6 +41,8 @@ namespace Harmony
 		public HarmonyMethod(Type type, string name, Type[] parameters = null)
 		{
 			var method = AccessTools.Method(type, name, parameters);
+			if (method == null)
+				throw new Exception($"Method cannot be null. {type}.{name} does not exist.");
 			ImportMethod(method);
 		}
 

--- a/Harmony/HarmonyMethod.cs
+++ b/Harmony/HarmonyMethod.cs
@@ -31,6 +31,10 @@ namespace Harmony
 				if (infos != null)
 					Merge(infos).CopyTo(this);
 			}
+			else
+			{
+				throw new Exception("Method cannot be null.");
+			}
 		}
 
 		public HarmonyMethod(MethodInfo method)
@@ -41,8 +45,6 @@ namespace Harmony
 		public HarmonyMethod(Type type, string name, Type[] parameters = null)
 		{
 			var method = AccessTools.Method(type, name, parameters);
-			if (method == null)
-				throw new Exception($"Method cannot be null. {type}.{name} does not exist.");
 			ImportMethod(method);
 		}
 

--- a/Harmony/MethodPatcher.cs
+++ b/Harmony/MethodPatcher.cs
@@ -328,6 +328,8 @@ namespace Harmony
 				{
 					if (AccessTools.GetReturnedType(original) == typeof(void))
 						throw new Exception("Cannot get result from void method " + original.FullDescription());
+					if (AccessTools.GetReturnedType(original) != patchParam.ParameterType)
+						throw new Exception("Return type mismatch from method " + original.FullDescription());
 					var ldlocCode = patchParam.ParameterType.IsByRef ? OpCodes.Ldloca : OpCodes.Ldloc;
 					Emitter.Emit(il, ldlocCode, variables[RESULT_VAR]);
 					continue;

--- a/Harmony/MethodPatcher.cs
+++ b/Harmony/MethodPatcher.cs
@@ -326,10 +326,11 @@ namespace Harmony
 
 				if (patchParam.Name == RESULT_VAR)
 				{
-					if (AccessTools.GetReturnedType(original) == typeof(void))
+					var originalRetType = AccessTools.GetReturnedType(original);
+					if (originalRetType == typeof(void))
 						throw new Exception("Cannot get result from void method " + original.FullDescription());
-					if (AccessTools.GetReturnedType(original) != patchParam.ParameterType)
-						throw new Exception("Return type mismatch from method " + original.FullDescription());
+					if (patchParam.ParameterType != typeof(object) && originalRetType != patchParam.ParameterType && patchParam.ParameterType.IsSubclassOf(originalRetType))
+					  throw new Exception("Return type mismatch from method " + original.FullDescription());
 					var ldlocCode = patchParam.ParameterType.IsByRef ? OpCodes.Ldloca : OpCodes.Ldloc;
 					Emitter.Emit(il, ldlocCode, variables[RESULT_VAR]);
 					continue;


### PR DESCRIPTION
- Do not allow HarmonyMethod to refer to a non-existant method
- Do not allow Postfix patch to change return type (bad ducks)