### PR TITLE
Fix spelling of "priority" field name

### DIFF
--- a/Harmony/Attributes.cs
+++ b/Harmony/Attributes.cs
@@ -218,9 +218,9 @@ namespace Harmony
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 	public class HarmonyPriority : HarmonyAttribute
 	{
-		public HarmonyPriority(int prioritiy)
+		public HarmonyPriority(int priority)
 		{
-			info.prioritiy = prioritiy;
+			info.priority = priority;
 		}
 	}
 

--- a/Harmony/HarmonyMethod.cs
+++ b/Harmony/HarmonyMethod.cs
@@ -14,7 +14,7 @@ namespace Harmony
 		public string methodName;
 		public MethodType? methodType;
 		public Type[] argumentTypes;
-		public int prioritiy = -1;
+		public int priority = -1;
 		public string[] before;
 		public string[] after;
 

--- a/Harmony/PatchFunctions.cs
+++ b/Harmony/PatchFunctions.cs
@@ -13,7 +13,7 @@ namespace Harmony
 		{
 			if (info == null || info.method == null) return;
 
-			var priority = info.prioritiy == -1 ? Priority.Normal : info.prioritiy;
+			var priority = info.priority == -1 ? Priority.Normal : info.priority;
 			var before = info.before ?? new string[0];
 			var after = info.after ?? new string[0];
 
@@ -29,7 +29,7 @@ namespace Harmony
 		{
 			if (info == null || info.method == null) return;
 
-			var priority = info.prioritiy == -1 ? Priority.Normal : info.prioritiy;
+			var priority = info.priority == -1 ? Priority.Normal : info.priority;
 			var before = info.before ?? new string[0];
 			var after = info.after ?? new string[0];
 
@@ -45,7 +45,7 @@ namespace Harmony
 		{
 			if (info == null || info.method == null) return;
 
-			var priority = info.prioritiy == -1 ? Priority.Normal : info.prioritiy;
+			var priority = info.priority == -1 ? Priority.Normal : info.priority;
 			var before = info.before ?? new string[0];
 			var after = info.after ?? new string[0];
 


### PR DESCRIPTION
The `priority` field in `HarmonyMethod` is currently misspelled `prioritiy`. This typo also occurs in the parameter name for the explicit `HarmonyPriority` constructor.

[This line](https://github.com/pardeike/Harmony/compare/master...ayan4m1:fix/priority-name?expand=1#diff-61f938e2025ec01f805d23e93979ad2cR17) may be a breaking change for downstream users, but the fix is dead simple.

Also, apologies as I am not intimately familiar with the codebase, but is there a reason why the public fields of `HarmonyMethod` are camelCase and not CamelCase?