### PR TITLE
slightly improved error reporting

### DIFF
--- a/Harmony/PatchProcessor.cs
+++ b/Harmony/PatchProcessor.cs
@@ -66,7 +66,7 @@ namespace Harmony
 				foreach (var original in originals)
 				{
 					if (original == null)
-						throw new NullReferenceException("original");
+						throw new NullReferenceException($"Null method for {instance.Id}.");
 
 					var individualPrepareResult = RunMethod<HarmonyPrepare, bool>(true, original);
 					if (individualPrepareResult)

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -107,9 +107,12 @@ namespace Harmony
 				{
 					result = FindIncludingBaseTypes(type, t => t.GetMethod(name, all));
 				}
-				catch (AmbiguousMatchException)
+				catch (AmbiguousMatchException ex)
 				{
 					result = FindIncludingBaseTypes(type, t => t.GetMethod(name, all, null, new Type[0], modifiers));
+
+					if (result == null)
+						throw new AmbiguousMatchException($"Ambiguous match in Harmony patch for {type}:{name}." + ex);
 				}
 			}
 			else


### PR DESCRIPTION
Ambiguous matches that were caught now throw when there's no match and inform you where you screwed up.

Null originals now show the Harmony.ID rather than just the vague error of "original". Should people screw up their overloads or typo the target method, they can theoretically change their harmony ID to more easily find the offending patch.