### PR TITLE
further improvements to error reporting

### DIFF
--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -119,7 +119,14 @@ namespace Harmony
 			{
 				result = FindIncludingBaseTypes(type, t => t.GetMethod(name, all, null, parameters, modifiers));
 			}
-			if (result == null) return null;
+
+			if (result == null)
+			{
+				if (HarmonyInstance.DEBUG)
+					FileLog.Log($"Harmony could not find method {type.FullName}:{name} to target using the {parameters?.Length ?? 0} parameters given.");
+
+				return null;
+			}
 			if (generics != null) result = result.MakeGenericMethod(generics);
 			return result;
 		}


### PR DESCRIPTION
similar to my previous PR. Should be self-explanatory.

Some thoughts: 
- It doesn't throw but maybe it should. As far as I can tell, MethodPatcher.CreatePatchedMethod() is where it should throw, but by then it's too late in a lot of regular use cases as Harmony will likely have already encountered a NRE elsewhere. Throwing this early may have side-effects I'm not aware of.

- AccessTools.DeclaredMethod(), which is very similar in structure, does not have the same level of try/catch and error reporting.