### PR TITLE
FieldRef FieldType check and option to ignore DeclaringType check

### DIFF
--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -737,7 +737,7 @@ namespace Harmony
 		}
 
 		/// <summary>Creates a field reference</summary>
-		/// <typeparam name="T">The class the field is defined in</typeparam>
+		/// <typeparam name="T">The class the field is defined in or "object" if type cannot be accessed at compile time</typeparam>
 		/// <typeparam name="U">The type of the field</typeparam>
 		/// <param name="fieldInfo">FieldInfo for the field</param>
 		/// <returns>A read and writable field reference</returns>
@@ -746,7 +746,10 @@ namespace Harmony
 		{
 			if (fieldInfo == null)
 				throw new ArgumentException("FieldInfo for FieldRefAccess is null.");
-			if (fieldInfo.DeclaringType == null || !fieldInfo.DeclaringType.IsAssignableFrom(typeof(T)))
+			if (!typeof(U).IsAssignableFrom(fieldInfo.FieldType))
+				throw new ArgumentException("FieldInfo type does not match FieldRefAccess return type.");
+			if (typeof(T) != typeof(object) &&
+			    (fieldInfo.DeclaringType == null || !fieldInfo.DeclaringType.IsAssignableFrom(typeof(T))))
 				throw new MissingFieldException(typeof(T).Name, fieldInfo.Name);
 
 			var s_name = "__refget_" + typeof(T).Name + "_fi_" + fieldInfo.Name;

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -183,7 +183,7 @@ namespace HarmonyTests
 			var newValue = AccessToolsClass.field1Value + "1";
 			value = newValue;
 			Assert.AreEqual(newValue, fieldInfo.GetValue(instance));
-	  }
+		}
 
 		[Test]
 		public void AccessTools_FieldRefAccess_ByFieldInfo()
@@ -198,7 +198,7 @@ namespace HarmonyTests
 			var newValue = AccessToolsClass.field1Value + "1";
 			value = newValue;
 			Assert.AreEqual(newValue, fieldInfo.GetValue(instance));
-	  }
+		}
 
 		[Test]
 		public void AccessTools_FieldRefAccess_ByFieldInfo_Readonly()
@@ -213,9 +213,9 @@ namespace HarmonyTests
 			var newValue = AccessToolsClass.field2Value + "1";
 			value = newValue;
 			Assert.AreEqual(newValue, fieldInfo.GetValue(instance));
-	  }
+		}
 
-	  [Test]
+		[Test]
 		public void AccessTools_FieldRefAccess_ByFieldInfo_Static()
 		{
 			var fieldInfo = typeof(AccessToolsClass).GetField("field3", BindingFlags.Static | BindingFlags.NonPublic);
@@ -245,5 +245,20 @@ namespace HarmonyTests
 			value = newValue;
 			Assert.AreEqual(newValue, fieldInfo.GetValue(instance));
 		}
-   }
+
+		[Test]
+		public void AccessTools_FieldRefAccess_Anonymous()
+		{
+			var fieldInfo = typeof(AccessToolsClass).GetField("field", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.IsNotNull(fieldInfo);
+			var instance = new AccessToolsClass();
+			var fieldRef = AccessTools.FieldRefAccess<object, string>(fieldInfo);
+			ref var value = ref fieldRef(instance);
+
+			Assert.AreEqual(AccessToolsClass.field1Value, value);
+			var newValue = AccessToolsClass.field1Value + "1";
+			value = newValue;
+			Assert.AreEqual(newValue, fieldInfo.GetValue(instance));
+		}
+	}
 }


### PR DESCRIPTION
Option to pass declaring type as object to FieldRef for cases where declaring type might be private nested type. Also check that FieldRef return type is actually assignable.