### PR TITLE
Doc fix + ArgumentException on null or empty id

### DIFF
--- a/Harmony/Documentation/articles/patching-prefix.md
+++ b/Harmony/Documentation/articles/patching-prefix.md
@@ -80,7 +80,7 @@ class Patch
         if (i > 5)
         {
             __result = true; // any call to IsFullAfterTakingIn(i) where i > 5 now immediately returns true
-	    return false; // skips the original and its expensive calculations
+           return false; // skips the original and its expensive calculations
         }
         return true; // make sure you only skip if really necessary
     }

--- a/Harmony/Public/HarmonyInstance.cs
+++ b/Harmony/Public/HarmonyInstance.cs
@@ -57,7 +57,7 @@ namespace Harmony
 		///
 		public static HarmonyInstance Create(string id)
 		{
-			if (id == null) throw new Exception("id cannot be null");
+			if (string.IsNullOrEmpty(id)) throw new ArgumentException("id cannot be null or empty");
 			return new HarmonyInstance(id);
 		}
 


### PR DESCRIPTION
b3368e3 fixes a tabs vs spaces mistake I introduced in #167.

The argument exception we discussed on discord.