### PR TITLE
Fixes for DynamicMethod patching

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -224,10 +224,9 @@ namespace HarmonyLib
 
 		static HarmonyArgument[] GetArgumentAttributes(this MethodInfo method)
 		{
-			if (method is DynamicMethod)
+			if (method == null || method is DynamicMethod)
 				return default;
 			
-			if (method == null) return new HarmonyArgument[0];
 			var attributes = method.GetCustomAttributes(false);
 			return AllHarmonyArguments(attributes);
 		}

--- a/HarmonyTests/Patching/DynamicMethodPatches.cs
+++ b/HarmonyTests/Patching/DynamicMethodPatches.cs
@@ -1,0 +1,42 @@
+using HarmonyLib;
+using NUnit.Framework;
+
+namespace HarmonyLibTests
+{
+	[TestFixture]
+	public class DynamicMethodPatches
+	{
+		[Test]
+		public void ByRefResultPrefix()
+		{
+			var originalClass = typeof(Assets.Class11);
+			Assert.IsNotNull(originalClass);
+
+			var originalMethod = originalClass.GetMethod(nameof(Assets.Class11.TestMethod));
+			Assert.IsNotNull(originalMethod);
+
+			var patchClass = typeof(Assets.Class11Patch);
+			Assert.IsNotNull(patchClass);
+
+			var prefix = patchClass.GetMethod(nameof(Assets.Class11Patch.Prefix));
+			Assert.IsNotNull(prefix);
+
+			var harmonyInstance = new Harmony("test");
+			Assert.IsNotNull(harmonyInstance);
+
+			var patchResult = harmonyInstance.Patch(
+				original: originalMethod,
+				prefix: new HarmonyMethod(prefix));
+
+			Assert.IsNotNull(patchResult);
+
+			var instance = new Assets.Class11();
+			var result = instance.TestMethod(0);
+
+			Assert.IsFalse(instance.originalMethodRan);
+			Assert.IsTrue(Assets.Class11Patch.prefixed);
+
+			Assert.AreEqual("patched", result);
+		}
+   }
+}


### PR DESCRIPTION
I've also included a unit test which is what I've been using for reproduction.

Note that in `Assets.Class11` I've included an `int dummy` parameter, which is required to trigger failures that are fixed in MethodPatcher.cs line 234 and line 300.

I've tested this in both regular .NET 4.5 runtime and Unity 5.x which contains the old mono implementation. Fix on line 234 was only needed for the old mono runtime, it works fine without it on regular .NET.

I have not tested this on Unity 2017.3, however I believe the new mono runtime included with it would work, similar to the (more compliant) .NET implementation.  Unity 2018 and above do not apply as they ship mscorlib with the stubbed System.Reflection.Emit runtime.