### PR TITLE
add a convenient factory to generate transpilers

### DIFF
--- a/Harmony/Public/PatchProcessor.cs
+++ b/Harmony/Public/PatchProcessor.cs
@@ -265,9 +265,9 @@ namespace HarmonyLib
 
 		void PrepareType()
 		{
-			var mainPrepareResult = RunMethod<HarmonyPrepare, bool>(true);
-			if (mainPrepareResult == false)
-				return;
+			//var mainPrepareResult = RunMethod<HarmonyPrepare, bool>(true);
+			//if (mainPrepareResult == false)
+			//	return;
 
 			var originalMethodType = containerAttributes.methodType;
 

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -12,26 +12,31 @@ namespace HarmonyLib
 	/// <summary>A helper class for reflection related functions</summary>
 	public static class AccessTools
 	{
-		/// <summary>Shortcut to simplify the use of reflections and make it work for any access level</summary>
-		public static BindingFlags all = BindingFlags.Public
-			| BindingFlags.NonPublic
-			| BindingFlags.Instance
-			| BindingFlags.Static
-			| BindingFlags.GetField
-			| BindingFlags.SetField
-			| BindingFlags.GetProperty
-			| BindingFlags.SetProperty;
+        /// <summary>Shortcut to simplify the use of reflections and make it work for any access level</summary>
+        public static BindingFlags all = BindingFlags.Public
+            | BindingFlags.NonPublic
+            | BindingFlags.Instance
+            | BindingFlags.Static
+            | BindingFlags.GetField
+            | BindingFlags.SetField
+            | BindingFlags.GetProperty
+            | BindingFlags.SetProperty
+            | BindingFlags.FlattenHierarchy;
 
 		/// <summary>Shortcut to simplify the use of reflections and make it work for any access level but only within the current type</summary>
 		public static BindingFlags allDeclared = all | BindingFlags.DeclaredOnly;
-
-		/// <summary>Gets a type by name. Prefers a full name with namespace but falls back to the first type matching the name otherwise</summary>
-		/// <param name="name">The name</param>
-		/// <returns>A Type</returns>
-		///
-		public static Type TypeByName(string name)
+        static readonly Dictionary<string, Type> KeywordTypes = new Dictionary<string, Type>{ { "bool", typeof(bool) }, { "byte", typeof(byte) }, { "char", typeof(char) },{"decimal",typeof(decimal)
+},{"double",typeof(double)},{"float",typeof(float)},{"int",typeof(int)},{"long",typeof(long)},{"sbyte",typeof(sbyte)},{"short",typeof(short)},{"string",typeof(string)},{"uint",typeof(uint)},{"ulong",typeof(ulong)},{"ushort",typeof(ushort)}};
+        /// <summary>Gets a type by name. Prefers a full name with namespace but falls back to the first type matching the name otherwise</summary>
+        /// <param name="name">The name</param>
+        /// <returns>A Type</returns>
+        ///
+        public static Type TypeByName(string name)
 		{
-			var type = Type.GetType(name, false);
+            Type type;
+            KeywordTypes.TryGetValue(name, out type);
+            if (type != null) return type;
+            type = Type.GetType(name, false);
 			if (type == null)
 				type = AppDomain.CurrentDomain.GetAssemblies()
 					.SelectMany(x => x.GetTypes())

--- a/Harmony/Tools/TranspilerFactory.cs
+++ b/Harmony/Tools/TranspilerFactory.cs
@@ -1,124 +1,202 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Text;
 using System.Text.RegularExpressions;
 
+#pragma warning disable CS1591
 namespace HarmonyLib
 {
-    public static class CodeParser
+    /// <summary>
+    /// Extend the CodeInstruction class to hold some options
+    /// </summary>
+    public class CodeInstructionEx : CodeInstruction
     {
-        public static readonly OpCode AnyOpcode = (OpCode)typeof(OpCode).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0].Invoke(new object[] { 256, -257283419 });
-        public static readonly object AnyOprand = "*";
-        public static readonly OpCode LocalvarOpcode = (OpCode)typeof(OpCode).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0].Invoke(new object[] { 257, 279317166 });
-        public static readonly OpCode LabelOpcode = (OpCode)typeof(OpCode).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0].Invoke(new object[] { 258, 279317166 });
-        public static readonly Regex MatchMethod = new Regex(@"^(.*?)::?(.*?)(?:\((.*?)\))?$");
-        public static readonly Dictionary<string, Type> KeywordTypes = new Dictionary<string, Type>{ { "bool", typeof(bool) }, { "byte", typeof(byte) }, { "char", typeof(char) },{"decimal",typeof(decimal)
-},{"double",typeof(double)},{"float",typeof(float)},{"int",typeof(int)},{"long",typeof(long)},{"sbyte",typeof(sbyte)},{"short",typeof(short)},{"string",typeof(string)},{"uint",typeof(uint)},{"ulong",typeof(ulong)},{"ushort",typeof(ushort)}};
-        public static Type String2Type(string str)
+        /// <summary>
+        /// options
+        /// </summary>
+        public enum Options
         {
-            Type t;
-            KeywordTypes.TryGetValue(str, out t);
-            if (t == null) t = AccessTools.TypeByName(str);
-            return t;
+            /// <summary>
+            /// Same as original
+            /// </summary>
+            None,
+            /// <summary>
+            /// Matched with any opcode and any operand.
+            /// </summary>
+            AnyOpcode,
+            /// <summary>
+            /// Matched with specific opcode and arbitrary operand.
+            /// </summary>
+            AnyOperand,
+            /// <summary>
+            /// Declare a local var
+            /// </summary>
+            DeclareVar,
+            /// <summary>
+            /// Mark a label. You can used any label of number without defining it.
+            /// </summary>
+            DeclareLabel
         }
-        public static CodeInstruction Parse(string str)
+        public Options option;
+        public CodeInstructionEx(CodeInstruction instruction, Options opt = Options.None) : base(instruction) => option = opt;
+        public CodeInstructionEx(OpCode opcode, object operand = null, Options opt = Options.None) : base(opcode, operand) => option = opt;
+        public CodeInstructionEx(OpCode opcode, Options opt) : base(opcode, null) => option = opt;
+        public CodeInstructionEx(Options opt, object operand = null) : base(OpCodes.Nop, operand)
         {
-            if (string.IsNullOrEmpty(str))
-                throw new Exception("String to Parse is null or empty");
+            option = opt;
+            if (opt == Options.None || opt == Options.AnyOperand) throw new Exception();
+        }
+        public override string ToString()
+        {
+            switch (option)
+            {
+                case Options.AnyOpcode:
+                    return "*";
+                case Options.AnyOperand:
+                    return opcode.ToString() + " *";
+                case Options.DeclareVar:
+                    return "Localvar " + operand.ToString();
+                case Options.DeclareLabel:
+                    return "Label " + operand.ToString();
+                default:
+                    if (opcode.OperandType == OperandType.InlineNone) return opcode.ToString();
+                    return base.ToString();
+            }
+        }
+        static readonly OpCode[] array = { OpCodes.Ldloc_S, OpCodes.Ldloca_S, OpCodes.Stloc_S, OpCodes.Ldloc, OpCodes.Ldloca, OpCodes.Stloc };
+        public bool OperandIsVar { get => Array.IndexOf<OpCode>(array, opcode) != -1; }
+        public bool OperandIsLabel { get => opcode.OperandType == OperandType.InlineBrTarget || opcode.OperandType == OperandType.ShortInlineBrTarget; }
+        /// <summary>
+        /// Matching CodeInstruction with the option
+        /// </summary>
+        /// <param name="code"></param>
+        /// <returns></returns>
+        public bool Match(CodeInstruction code)
+        {
+            switch (option)
+            {
+                case Options.None:
+                    return opcode == code.opcode && operand == code.operand;
+                case Options.AnyOpcode:
+                    return true;
+                case Options.AnyOperand:
+                    return opcode == code.opcode;
+                default:
+                    throw new Exception("Declare CodeInstruction cannot match with others");
+            }
+        }
+    }
+    /// <summary>
+    /// Parse input string with wildcards to CodeInstructionEx(s). Case insensitive. 
+    /// Better not type any extra space !!!
+    /// </summary>
+    /// <remarks>
+    /// The format of MethodName is [type name][one or two colon][method name]([parameter types seperated by comma])(optional)
+    /// The format of FieldName is [type name][one or two colon][field name]
+    /// declare local var is localvar [type name]
+    /// declare label is label [zero-based number]
+    /// </remarks>
+    /// <example>
+    /// call string::Concat(string, string)
+    /// br 0
+    /// label 0
+    /// localvar int
+    /// </example>
+    public static class Parser
+    {
+        static readonly Regex MatchMethod = new Regex(@"^(.*?)(?:::?(.*?))?(?:\((.*?)\))?$");
+        public static MethodBase ParseMethod(string str)
+        {
+            var match = MatchMethod.Match(str);
+            if (!match.Success) return null;
+            MethodBase method;
+            var type = AccessTools.TypeByName(match.Groups[1].Value);
+            var methodstr = match.Groups[2].Value;
+            var argstr = match.Groups[3].Value;
+            Type[] args = null;
+            if (argstr != "")
+            {
+                var t = argstr.Split(',');
+                args = new Type[t.Length];
+                for (int i = 0; i < t.Length; i++) args[i] = AccessTools.TypeByName(t[i].Trim());
+            }
+            if (methodstr == "") method = AccessTools.Constructor(type, args);
+            else method = AccessTools.Method(type, methodstr, args);
+            return method;
+        }
+        static readonly Regex MatchField = new Regex(@"^(.*?)::?(.*?)$");
+        public static FieldInfo ParseField(string str)
+        {
+            var match = MatchField.Match(str);
+            if (!match.Success) return null;
+            var type = AccessTools.TypeByName(match.Groups[1].Value);
+            var fieldstr = match.Groups[2].Value;
+            return AccessTools.Field(type, fieldstr);
+        }
+        public static CodeInstructionEx ParseSingle(string str)
+        {
+            if (string.IsNullOrEmpty(str) || str == "*") return new CodeInstructionEx(CodeInstructionEx.Options.AnyOpcode);
             var parts = str.Split(new char[] { ' ' }, 2);
-            string opcodestr = parts[0];
-            OpCode opcode = AnyOpcode;
-            if (opcodestr != "*")
+            string opcodestr = parts[0].ToLower();
+            if (opcodestr == "*") return new CodeInstructionEx(CodeInstructionEx.Options.AnyOpcode);
+            if (opcodestr == "localvar")
+                return new CodeInstructionEx(CodeInstructionEx.Options.DeclareVar, AccessTools.TypeByName(parts[1]));
+            if (opcodestr == "label")
+                return new CodeInstructionEx(CodeInstructionEx.Options.DeclareLabel, Convert.ToInt32(parts[1]));
+            opcodestr = opcodestr.Replace('.', '_');
+            var opcode = (OpCode)typeof(OpCodes).GetField(opcodestr, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public).GetValue(null);
+            if (parts.Length == 1 || opcode.OperandType == OperandType.InlineNone) return new CodeInstructionEx(opcode);
+            string oprandstr = parts[1];
+            if (oprandstr == "*")
+                return new CodeInstructionEx(opcode, CodeInstructionEx.Options.AnyOperand);
+            object obj = null;
+            switch (opcode.OperandType)
             {
-                opcodestr = opcodestr.ToLower();
-                if (opcodestr == "localvar") return new CodeInstruction(LocalvarOpcode, String2Type(parts[1]));
-                if (opcodestr == "label") return new CodeInstruction(LabelOpcode, Convert.ToInt32(parts[1]));
-                opcodestr = opcodestr.Replace('.', '_');
-                opcode = (OpCode)typeof(OpCodes).GetField(opcodestr, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public).GetValue(null);
+                case OperandType.InlineMethod:
+                    obj = ParseMethod(oprandstr);
+                    break;
+                case OperandType.InlineField:
+                    obj = ParseField(oprandstr);
+                    break;
+                case OperandType.InlineString:
+                    obj = oprandstr;
+                    break;
+                case OperandType.InlineType:
+                    obj = AccessTools.TypeByName(oprandstr);
+                    break;
+                case OperandType.InlineI:
+                case OperandType.InlineBrTarget:
+                case OperandType.ShortInlineBrTarget:
+                    obj = Convert.ToInt32(oprandstr);
+                    break;
+                case OperandType.InlineVar:
+                case OperandType.ShortInlineI:
+                    obj = Convert.ToInt16(oprandstr);
+                    break;
+                case OperandType.ShortInlineVar:
+                case OperandType.InlineI8:
+                    obj = Convert.ToByte(oprandstr);
+                    break;
+                case OperandType.InlineR:
+                    obj = Convert.ToDouble(oprandstr);
+                    break;
+                case OperandType.ShortInlineR:
+                    obj = Convert.ToSingle(oprandstr);
+                    break;
             }
-            if (parts.Length == 1 || opcode.OperandType == OperandType.InlineNone)
-                return new CodeInstruction(opcode);
-            else
-            {
-                string oprandstr = parts[1];
-                if (oprandstr == "*")
-                    return new CodeInstruction(opcode, AnyOprand);
-                object obj = null;
-                switch (opcode.OperandType)
-                {
-                    case OperandType.InlineMethod:
-                        var result = MatchMethod.Match(oprandstr);
-                        if (!result.Success) obj = null;
-                        else
-                        {
-                            var type = String2Type(result.Groups[1].Value);
-                            var method = result.Groups[2].Value;
-                            var argstr = result.Groups[3].Value;
-                            Type[] args = null;
-                            if (argstr != "")
-                            {
-                                var t = argstr.Split(',');
-                                args = new Type[t.Length];
-                                for (int i = 0; i < t.Length; i++)
-                                {
-                                    var s = t[i].Trim();
-                                    KeywordTypes.TryGetValue(s, out args[i]);
-                                    if (args[i] == null) args[i] = String2Type(s);
-                                }
-                            }
-                            if (opcode == OpCodes.Newobj) obj = AccessTools.Constructor(type, args);
-                            else obj = AccessTools.Method(type, method, args);
-                        }
-                        break;
-                    case OperandType.InlineField:
-                        parts = oprandstr.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-                        obj = AccessTools.Field(String2Type(parts[0]), parts[1]);
-                        break;
-                    case OperandType.InlineString:
-                        obj = oprandstr;
-                        break;
-                    case OperandType.InlineType:
-                        obj = String2Type(oprandstr);
-                        break;
-                    case OperandType.InlineI:
-                    case OperandType.InlineBrTarget:
-                    case OperandType.ShortInlineBrTarget:
-                        obj = Convert.ToInt32(oprandstr);
-                        break;
-                    case OperandType.InlineVar:
-                    case OperandType.ShortInlineI:
-                        obj = Convert.ToInt16(oprandstr);
-                        break;
-                    case OperandType.ShortInlineVar:
-                    case OperandType.InlineI8:
-                        obj = Convert.ToByte(oprandstr);
-                        break;
-                    case OperandType.InlineR:
-                        obj = Convert.ToDouble(oprandstr);
-                        break;
-                    case OperandType.ShortInlineR:
-                        obj = Convert.ToSingle(oprandstr);
-                        break;
-                }
-                if (obj == null)
-                    throw new Exception("Unknown OperandType or Wrong operand");
-                return new CodeInstruction(opcode, obj);
-            }
+            if (obj == null)
+                throw new Exception("Unknown OperandType or Wrong operand");
+            return new CodeInstructionEx(opcode, obj);
         }
-        public static List<CodeInstruction> ParseMutiple(string str)
+        public static List<CodeInstructionEx> Parse(string str)
         {
             var codes = str.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            List<CodeInstruction> result = new List<CodeInstruction>(codes.Length);
+            List<CodeInstructionEx> result = new List<CodeInstructionEx>(codes.Length);
             for (int i = 0; i < codes.Length; i++)
-                result.Add(Parse(codes[i]));
-            return result;
-        }
-
-        public static bool isMatchWith(this CodeInstruction CodeWithMatchOption, CodeInstruction instr)
-        {
-            bool result = (CodeParser.AnyOpcode == CodeWithMatchOption.opcode) || CodeWithMatchOption.opcode == instr.opcode;
-            result &= (CodeParser.AnyOprand == CodeWithMatchOption.operand) || (CodeWithMatchOption.operand != null ? CodeWithMatchOption.operand.Equals(instr.operand) : null == instr.operand);
+                result.Add(ParseSingle(codes[i]));
             return result;
         }
     }
@@ -128,8 +206,8 @@ namespace HarmonyLib
     }
     class SearchDeleteTranspiler : ITranspiler
     {
-        List<CodeInstruction> search;
-        public SearchDeleteTranspiler(List<CodeInstruction> codes)
+        List<CodeInstructionEx> search;
+        public SearchDeleteTranspiler(List<CodeInstructionEx> codes)
         {
             if (codes == null || codes.Count <= 0) throw new Exception();
             search = codes;
@@ -149,12 +227,13 @@ namespace HarmonyLib
                     int count = 0;
                     foreach (var item in queue)
                     {
-                        if (search[count].isMatchWith(item)) count++;
+                        if (search[count].Match(item)) count++;
                         else break;
                     }
                     if (count >= search.Count)
                     {
                         queue.Clear();
+                        factory.TaskCount--;
                         yield break;
                     }
                 }
@@ -164,8 +243,8 @@ namespace HarmonyLib
     }
     class SearchTranspiler : ITranspiler
     {
-        List<CodeInstruction> search;
-        public SearchTranspiler(List<CodeInstruction> codes)
+        List<CodeInstructionEx> search;
+        public SearchTranspiler(List<CodeInstructionEx> codes)
         {
             if (codes == null || codes.Count <= 0) throw new Exception();
             search = codes;
@@ -185,12 +264,13 @@ namespace HarmonyLib
                     int count = 0;
                     foreach (var item in queue)
                     {
-                        if (search[count].isMatchWith(item)) count++;
+                        if (search[count].Match(item)) count++;
                         else break;
                     }
                     if (count >= search.Count)
                     {
                         while (queue.Count > 0) yield return queue.Dequeue();
+                        factory.TaskCount--;
                         yield break;
                     }
                 }
@@ -200,8 +280,8 @@ namespace HarmonyLib
     }
     class InsertTranspiler : ITranspiler
     {
-        List<CodeInstruction> list;
-        public InsertTranspiler(List<CodeInstruction> codes)
+        List<CodeInstructionEx> list;
+        public InsertTranspiler(List<CodeInstructionEx> codes)
         {
             if (codes == null || codes.Count <= 0) throw new Exception();
             list = codes;
@@ -214,38 +294,34 @@ namespace HarmonyLib
             var labels = factory.Labels;
             foreach (var code in list)
             {
-                var no = code.opcode.Value;
-                if (code.opcode == CodeParser.LocalvarOpcode) locals.Add(generator.DeclareLocal((Type)code.operand));
-                else if (code.opcode == CodeParser.LabelOpcode)
+                int index;
+                switch (code.option)
                 {
-                    var index = (int)code.operand;
-                    for (int i = labels.Count - 1; i < index; i++) labels.Add(generator.DefineLabel());
-                    var t = new List<Label>() { labels[index] };
-                    yield return new CodeInstruction(OpCodes.Nop) { labels = t };
+                    case CodeInstructionEx.Options.DeclareVar:
+                        locals.Add(generator.DeclareLocal((Type)code.operand));
+                        break;
+                    case CodeInstructionEx.Options.DeclareLabel:
+                        index = (int)code.operand;
+                        for (int i = labels.Count - 1; i < index; i++) labels.Add(generator.DefineLabel());
+                        var t = new List<Label>() { labels[index] };
+                        yield return new CodeInstruction(OpCodes.Nop) { labels = t };
+                        break;
+                    case CodeInstructionEx.Options.None:
+                        CodeInstruction result = code.Clone();
+                        if (code.OperandIsVar) result.operand = locals[Convert.ToInt32(code.operand)];
+                        else if (code.OperandIsLabel)
+                        {
+                            index = (int)code.operand;
+                            for (int i = labels.Count - 1; i < index; i++) labels.Add(generator.DefineLabel());
+                            result.operand = labels[index];
+                        }
+                        yield return result;
+                        break;
+                    default:
+                        throw new Exception();
                 }
-                else if (no == 17 || no == 18 || no == 19 || no == -500 || no == -499 || no == -498)
-                {
-                    code.operand = locals[Convert.ToInt32(code.operand)];
-                    yield return code;
-                }
-                else if (code.opcode.OperandType == OperandType.InlineBrTarget || code.opcode.OperandType == OperandType.ShortInlineBrTarget)
-                {
-                    var index = (int)code.operand;
-                    for (int i = labels.Count - 1; i < index; i++) labels.Add(generator.DefineLabel());
-                    code.operand = labels[index];
-                    yield return code;
-                }
-                else yield return code;
             }
-        }
-    }
-    class EndingTranspiler : ITranspiler
-    {
-        public EndingTranspiler() { }
-        public IEnumerable<CodeInstruction> TransMethod(TranspilerFactory factory)
-        {
-            var instructions = factory.CodeEnumerator;
-            while (instructions.MoveNext()) yield return instructions.Current;
+            factory.TaskCount--;
         }
     }
     class SkipTranspiler : ITranspiler
@@ -261,64 +337,199 @@ namespace HarmonyLib
             var t = count;
             var instructions = factory.CodeEnumerator;
             while (t > 0 && instructions.MoveNext()) t--;
+            factory.TaskCount--;
             return null;
         }
     }
+    class EndingTranspiler : ITranspiler
+    {
+        public EndingTranspiler() { }
+        public IEnumerable<CodeInstruction> TransMethod(TranspilerFactory factory)
+        {
+            var instructions = factory.CodeEnumerator;
+            while (instructions.MoveNext()) yield return instructions.Current;
+        }
+    }
+    /// <summary>
+    /// The delegate type of transpiler used in TranspilerFactory
+    /// </summary>
+    /// <param name="generator"></param>
+    /// <param name="instructions"></param>
+    /// <returns></returns>
     public delegate IEnumerable<CodeInstruction> TranspilerDelegate(ILGenerator generator, IEnumerable<CodeInstruction> instructions);
+    /// <summary>
+    /// A convenient Transpiler Factory to generate transpilers
+    /// It consist of a FIFO list of tasks such as Search, Delete and Replace which is executed in order.
+    /// </summary>
+    /// <example>
+    /// new TranspilerFactory().Replace(..., ...).PatchFor(harmony, "someType::someMethod");
+    /// </example>
     public class TranspilerFactory
     {
-        List<ITranspiler> transpilers;
-        TranspilerDelegate GetTranspiler;
+        // Instance
         internal ILGenerator Generator;
         internal IEnumerator<CodeInstruction> CodeEnumerator;
         internal List<LocalBuilder> Locals;
         internal List<Label> Labels;
-        public TranspilerFactory()
+        List<ITranspiler> tasks = new List<ITranspiler>();
+        public int TaskCount = 0;
+        void AddTask(ITranspiler task)
         {
-            transpilers = new List<ITranspiler>();
-            GetTranspiler = new TranspilerDelegate(Transpiler);
+            tasks.Add(task);
         }
-        public TranspilerFactory Search(string str)
+        /// <summary>
+        /// Search the instructions list, the position after search is just after the last element.
+        /// </summary>
+        /// <param name="codes"></param>
+        /// <returns></returns>
+        public TranspilerFactory Search(List<CodeInstructionEx> codes) { AddTask(new SearchTranspiler(codes)); return this; }
+        /// <summary>
+        /// Search the instructions list for certain times, the position after search is just after the last element.
+        /// </summary>
+        /// <param name="codes"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Search(List<CodeInstructionEx> codes, int num) { for (int i = 0; i < num; i++) Search(codes); return this; }
+        /// <summary>
+        /// Search the instructions list, the position after search is just after the last element.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public TranspilerFactory Search(string str) { Search(Parser.Parse(str)); return this; }
+        /// <summary>
+        /// Search the instructions list for certain times, the position after search is just after the last element.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Search(string str, int num) { var codes = Parser.Parse(str); for (int i = 0; i < num; i++) Search(codes); return this; }
+        /// <summary>
+        /// Insert without moving postion
+        /// </summary>
+        /// <param name="codes"></param>
+        /// <returns></returns>
+        public TranspilerFactory Insert(List<CodeInstructionEx> codes) { AddTask(new InsertTranspiler(codes)); return this; }
+        /// <summary>
+        /// Insert without moving postion
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public TranspilerFactory Insert(string str) { Insert(Parser.Parse(str)); return this; }
+        /// <summary>
+        /// Search the instructions list and delete it.
+        /// </summary>
+        /// <param name="codes"></param>
+        /// <returns></returns>
+        public TranspilerFactory Delete(List<CodeInstructionEx> codes) { AddTask(new SearchDeleteTranspiler(codes)); return this; }
+        /// <summary>
+        /// Search the instructions list and delete it for certain times
+        /// </summary>
+        /// <param name="codes"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Delete(List<CodeInstructionEx> codes, int num) { for (int i = 0; i < num; i++) Delete(codes); return this; }
+        /// <summary>
+        /// Search the instructions list and delete it.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public TranspilerFactory Delete(string str) { Delete(Parser.Parse(str)); return this; }
+        /// <summary>
+        /// Search the instructions list and delete it for certain times.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Delete(string str, int num) { var codes = Parser.Parse(str); for (int i = 0; i < num; i++) Delete(codes); return this; }
+        /// <summary>
+        /// Delete certain number of instructions at current position.
+        /// </summary>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Delete(int num) { AddTask(new SkipTranspiler(num)); return this; }
+        /// <summary>
+        /// Search the first instructions list and replace with the second.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <returns></returns>
+        public TranspilerFactory Replace(List<CodeInstructionEx> from, List<CodeInstructionEx> to) { Delete(from); Insert(to); return this; }
+        /// <summary>
+        /// Search the first instructions list and replace with the second for certain times.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Replace(List<CodeInstructionEx> from, List<CodeInstructionEx> to, int num) { for (int i = 0; i < num; i++) { Delete(from); Insert(to); } return this; }
+        /// <summary>
+        /// Search the first instructions list and replace with the second.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <returns></returns>
+        public TranspilerFactory Replace(string from, string to) { Replace(Parser.Parse(from), Parser.Parse(to)); return this; }
+        /// <summary>
+        /// Search the first instructions list and replace with the second for certain times.
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public TranspilerFactory Replace(string from, string to, int num) { var from_ = Parser.Parse(from); var to_ = Parser.Parse(to); for (int i = 0; i < num; i++) Replace(from_, to_); return this; }
+        public IEnumerable<CodeInstruction> Transpile(ILGenerator generator, IEnumerable<CodeInstruction> instr)
         {
-            transpilers.Add(new SearchTranspiler(CodeParser.ParseMutiple(str)));
-            return this;
-        }
-        public TranspilerFactory Replace(string from, string to)
-        {
-            transpilers.Add(new SearchDeleteTranspiler(CodeParser.ParseMutiple(from)));
-            transpilers.Add(new InsertTranspiler(CodeParser.ParseMutiple(to)));
-            return this;
-        }
-        public TranspilerFactory Insert(string str)
-        {
-            transpilers.Add(new InsertTranspiler(CodeParser.ParseMutiple(str)));
-            return this;
-        }
-        public TranspilerFactory Delete(string str)
-        {
-            transpilers.Add(new SearchDeleteTranspiler(CodeParser.ParseMutiple(str)));
-            return this;
-        }
-        public TranspilerFactory Delete(int num)
-        {
-            transpilers.Add(new SkipTranspiler(num));
-            return this;
-        }
-        public HarmonyMethod GetTranspilerMethod() => new HarmonyMethod(GetTranspiler.Method);
-        public IEnumerable<CodeInstruction> Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instr)
-        {
-            if (transpilers.Count == 0 || !(transpilers[transpilers.Count - 1] is EndingTranspiler)) transpilers.Add(new EndingTranspiler());
+            if (tasks.Count == 0 || !(tasks[tasks.Count - 1] is EndingTranspiler)) tasks.Add(new EndingTranspiler());
+            TaskCount = tasks.Count - 1;
             Generator = generator;
             CodeEnumerator = instr.GetEnumerator();
             Locals = new List<LocalBuilder>();
             Labels = new List<Label>();
-            foreach (var t in transpilers)
+            foreach (var t in tasks)
             {
                 foreach (var code in t.TransMethod(this))
                 {
                     yield return code;
                 }
             }
+            if (throwOnNotCompleted && TaskCount > 0)
+                throw new Exception("TranspilerFactory did not complete the specified number of tasks. ");
         }
+        public void PatchFor(Harmony instance, string method)
+        {
+            factory = this;
+            instance.Patch(Parser.ParseMethod(method), transpiler: GetHarmonyMethod());
+            factory = null;
+        }
+        public void PatchFor(Harmony instance, MethodBase original)
+        {
+            factory = this;
+            instance.Patch(original, transpiler: GetHarmonyMethod());
+            factory = null;
+        }
+        // Static
+        public static bool throwOnNotCompleted = true;
+        public static TranspilerFactory factory;
+        static IEnumerable<CodeInstruction> Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions) => factory.Transpile(generator, instructions);
+        public static HarmonyMethod GetHarmonyMethod() => new HarmonyMethod(((TranspilerDelegate)Transpiler).Method);
+
+    }
+    /// <summary>
+    /// A abstract version of TranspilerFactory
+    /// Inherent from this and initialize factory in function Prepare
+    /// Not recommended for multiple originalMethod (because Prepare will be called multiple times).
+    /// </summary>
+    /// <example>
+    /// [HarmonyPatch(typeof(someType), "someMethod")]
+    /// class MyPatch : TranspilerPatch
+    /// {
+    ///     static void Prepare() => factory.Replace(..., ...);
+    /// }
+    /// </example>
+    public abstract class TranspilerPatch
+    {
+        protected static TranspilerFactory factory = new TranspilerFactory();
+        protected static IEnumerable<CodeInstruction> Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions) => factory.Transpile(generator, instructions);
+        protected static void Cleanup() => factory = new TranspilerFactory();
     }
 }

--- a/Harmony/Tools/TranspilerFactory.cs
+++ b/Harmony/Tools/TranspilerFactory.cs
@@ -1,0 +1,305 @@
+using HarmonyLib;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace HarmonyLib
+{
+    public static class CodeParser
+    {
+        public static readonly OpCode AnyOpcode = (OpCode)typeof(OpCode).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0].Invoke(new object[] { 256, -257283419 });
+        public static readonly object AnyOprand = "*";
+        public static readonly Regex MatchMethod = new Regex(@"^(.*?)::?(.*?)(?:\((.*?)\))?$");
+        public static readonly Dictionary<string, Type> KeywordTypes = new Dictionary<string, Type>{ { "bool", typeof(bool) }, { "byte", typeof(byte) }, { "char", typeof(char) },{"decimal",typeof(decimal)
+},{"double",typeof(double)},{"float",typeof(float)},{"int",typeof(int)},{"long",typeof(long)},{"sbyte",typeof(sbyte)},{"short",typeof(short)},{"string",typeof(string)},{"uint",typeof(uint)},{"ulong",typeof(ulong)},{"ushort",typeof(ushort)}};
+        public static Type String2Type(string str)
+        {
+            Type t;
+            KeywordTypes.TryGetValue(str, out t);
+            if (t == null) t = AccessTools.TypeByName(str);
+            return t;
+        }
+        public static CodeInstruction Parse(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+                throw new Exception("String to Parse is null or empty");
+            var parts = str.Split(new char[] { ' ' }, 2);
+            string opcodestr = parts[0];
+            OpCode opcode = AnyOpcode;
+            if (opcodestr != "*")
+            {
+                opcodestr = opcodestr.Replace('.', '_');
+                opcode = (OpCode)typeof(OpCodes).GetField(opcodestr, BindingFlags.IgnoreCase | BindingFlags.Static | BindingFlags.Public).GetValue(null);
+            }
+            if (parts.Length == 1)
+                return new CodeInstruction(opcode);
+            else
+            {
+                string oprandstr = parts[1];
+                if (oprandstr == "*" || opcode.OperandType == OperandType.InlineNone)
+                    return new CodeInstruction(opcode, AnyOprand);
+                else
+                {
+                    object obj = null;
+                    if (opcode.OperandType == OperandType.InlineMethod)
+                    {
+                        var result = MatchMethod.Match(oprandstr);
+                        if (!result.Success) obj = null;
+                        else
+                        {
+                            var type = String2Type(result.Groups[1].Value);
+                            var method = result.Groups[2].Value;
+                            var argstr = result.Groups[3].Value;
+                            Type[] args = null;
+                            if (argstr != "")
+                            {
+                                var t = argstr.Split(',');
+                                args = new Type[t.Length];
+                                for (int i = 0; i < t.Length; i++)
+                                {
+                                    var s = t[i].Trim();
+                                    KeywordTypes.TryGetValue(s, out args[i]);
+                                    if (args[i] == null) args[i] = String2Type(s);
+                                }
+                            }
+                            if (opcode == OpCodes.Newobj) obj = AccessTools.Constructor(type, args);
+                            else obj = AccessTools.Method(type, method, args);
+                        }
+                    }
+                    else if (opcode.OperandType == OperandType.InlineField)
+                    {
+                        parts = oprandstr.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+                        obj = AccessTools.Field(String2Type(parts[0]), parts[1]);
+                    }
+                    else if (opcode.OperandType == OperandType.InlineString)
+                        obj = oprandstr;
+                    else if (opcode.OperandType == OperandType.InlineI)
+                        obj = Convert.ToInt32(oprandstr);
+                    if (obj == null)
+                        throw new Exception("Unknown OperandType or Wrong operand");
+                    return new CodeInstruction(opcode, obj);
+                }
+            }
+        }
+        public static List<CodeInstruction> ParseMutiple(string str)
+        {
+            var codes = str.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            List<CodeInstruction> result = new List<CodeInstruction>(codes.Length);
+            for (int i = 0; i < codes.Length; i++)
+                result.Add(Parse(codes[i]));
+            return result;
+        }
+
+        public static bool isMatchWith(this CodeInstruction CodeWithMatchOption, CodeInstruction instr)
+        {
+            bool result = (CodeParser.AnyOpcode == CodeWithMatchOption.opcode) || CodeWithMatchOption.opcode == instr.opcode;
+            result &= (CodeParser.AnyOprand == CodeWithMatchOption.operand) || (CodeWithMatchOption.operand != null ? CodeWithMatchOption.operand.Equals(instr.operand) : null == instr.operand);
+            return result;
+        }
+    }
+    interface ITranspiler
+    {
+        IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions);
+    }
+    public class SearchDeleteTranspiler : ITranspiler
+    {
+        public List<CodeInstruction> search;
+        public SearchDeleteTranspiler(List<CodeInstruction> codes)
+        {
+            if (codes == null || codes.Count <= 0) throw new Exception();
+            search = codes;
+        }
+        public IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions)
+        {
+            CodeInstruction current;
+            Queue<CodeInstruction> queue = new Queue<CodeInstruction>();
+            while (instructions.MoveNext())
+            {
+                current = instructions.Current;
+                queue.Enqueue(current);
+                if (queue.Count > search.Count) yield return queue.Dequeue();
+                if (queue.Count == search.Count)
+                {
+                    int count = 0;
+                    foreach (var item in queue)
+                    {
+                        if (search[count].isMatchWith(item)) count++;
+                        else break;
+                    }
+                    if (count >= search.Count)
+                    {
+                        queue.Clear();
+                        yield break;
+                    }
+                }
+            }
+            while (queue.Count > 0) yield return queue.Dequeue();
+        }
+    }
+    public class SearchTranspiler : ITranspiler
+    {
+        public List<CodeInstruction> search;
+        public SearchTranspiler(List<CodeInstruction> codes)
+        {
+            if (codes == null || codes.Count <= 0) throw new Exception();
+            search = codes;
+        }
+        public IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions)
+        {
+            CodeInstruction current;
+            Queue<CodeInstruction> queue = new Queue<CodeInstruction>();
+            while (instructions.MoveNext())
+            {
+                current = instructions.Current;
+                queue.Enqueue(current);
+                if (queue.Count > search.Count) yield return queue.Dequeue();
+                if (queue.Count == search.Count)
+                {
+                    int count = 0;
+                    foreach (var item in queue)
+                    {
+                        if (search[count].isMatchWith(item)) count++;
+                        else break;
+                    }
+                    if (count >= search.Count)
+                    {
+                        while (queue.Count > 0) yield return queue.Dequeue();
+                        yield break;
+                    }
+                }
+            }
+            while (queue.Count > 0) yield return queue.Dequeue();
+        }
+    }
+    public class SearchReplaceTranspiler : ITranspiler
+    {
+        public List<CodeInstruction> search;
+        public List<CodeInstruction> replace;
+        public SearchReplaceTranspiler(List<CodeInstruction> codes, List<CodeInstruction> toreplace)
+        {
+            if (codes == null || codes.Count <= 0) throw new Exception();
+            search = codes;
+            if (toreplace == null || toreplace.Count <= 0) throw new Exception();
+            replace = toreplace;
+        }
+        public IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions)
+        {
+            CodeInstruction current;
+            Queue<CodeInstruction> queue = new Queue<CodeInstruction>();
+            while (instructions.MoveNext())
+            {
+                current = instructions.Current;
+                queue.Enqueue(current);
+                if (queue.Count > search.Count) yield return queue.Dequeue();
+                if (queue.Count == search.Count)
+                {
+                    int count = 0;
+                    foreach (var item in queue)
+                    {
+                        if (search[count].isMatchWith(item)) count++;
+                        else break;
+                    }
+                    if (count >= search.Count)
+                    {
+                        queue.Clear();
+                        foreach (var i in replace) yield return i;
+                        yield break;
+                    }
+                }
+            }
+            while (queue.Count > 0) yield return queue.Dequeue();
+        }
+    }
+    public class InsertTranspiler : ITranspiler
+    {
+        public List<CodeInstruction> list;
+        public InsertTranspiler(List<CodeInstruction> codes)
+        {
+            if (codes == null || codes.Count <= 0) throw new Exception();
+            list = codes;
+        }
+        public IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions)
+        {
+            return list;
+        }
+    }
+    public class EndingTranspiler : ITranspiler
+    {
+        public EndingTranspiler() { }
+        public IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions)
+        {
+            while (instructions.MoveNext()) yield return instructions.Current;
+        }
+    }
+    public class SkipTranspiler : ITranspiler
+    {
+        public int count;
+        public SkipTranspiler(int num)
+        {
+            if (num <= 0) throw new Exception();
+            count = num;
+        }
+        public IEnumerable<CodeInstruction> TransMethod(IEnumerator<CodeInstruction> instructions)
+        {
+            var t = count;
+            while (t > 0 && instructions.MoveNext()) ;
+            return null;
+        }
+    }
+    public delegate IEnumerable<CodeInstruction> TranspilerMethod(ILGenerator generator, IEnumerable<CodeInstruction> instructions);
+    public class TranspilerFactory
+    {
+        List<ITranspiler> transpilers;
+        public TranspilerFactory()
+        {
+            transpilers = new List<ITranspiler>();
+            GetTranspiler = new TranspilerType(Transpiler);
+        }
+        public TranspilerFactory Search(string str)
+        {
+            transpilers.Add(new SearchTranspiler(CodeParser.ParseMutiple(str)));
+            return this;
+        }
+        public TranspilerFactory Replace(string from, string to)
+        {
+            transpilers.Add(new SearchReplaceTranspiler(CodeParser.ParseMutiple(from), CodeParser.ParseMutiple(to)));
+            return this;
+        }
+        public TranspilerFactory Insert(string str)
+        {
+            transpilers.Add(new InsertTranspiler(CodeParser.ParseMutiple(str)));
+            return this;
+        }
+        public TranspilerFactory Delete(string str)
+        {
+            transpilers.Add(new SearchDeleteTranspiler(CodeParser.ParseMutiple(str)));
+            return this;
+        }
+        public TranspilerFactory Delete(int num)
+        {
+            transpilers.Add(new SkipTranspiler(num));
+            return this;
+        }
+        public delegate IEnumerable<CodeInstruction> TranspilerType(ILGenerator generator, IEnumerable<CodeInstruction> instr);
+        private TranspilerType GetTranspiler;
+        public HarmonyMethod GetTranspilerMethod() => new HarmonyMethod(GetTranspiler.Method);
+        public IEnumerable<CodeInstruction> Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instr)
+        {
+            var last = transpilers[transpilers.Count - 1];
+            if (!(last is EndingTranspiler)) transpilers.Add(new EndingTranspiler());
+            var iter = instr.GetEnumerator();
+            foreach (var t in transpilers)
+            {
+                foreach (var code in t.TransMethod(iter))
+                {
+                    yield return code;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I find quite of my code is duplicate when using harmony transpiler to patch.
So i made a TranspilerFactory because i didn't find something similar to this in Tools.
It can parse input string with wildcards to generate transpilers to replace,insert and delete.
Here is the usage:
```csharp
class Student
{
    public Student(string name)
    {
        Name = name;
    }
    private string Name;
    public void Speak(string something)
    {
        Console.WriteLine($"{Name} says : {something}");
    }
}
[HarmonyPatch(typeof(Student), "Speak")]
static class StudentSpeakPatch
{
    static IEnumerable<CodeInstruction> Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instr)
    => new TranspilerFactory().Delete("ldstr  says : ").Insert("ldstr  said nothing")
    .Replace("ldarg.1;call *", "call string::Concat(string, string)").Transpiler(generator, instr);
}
```
Part of my idea comes from /pull/9