### PR TITLE
Support target methods without body

### DIFF
--- a/Harmony/Internal/CodeTranspiler.cs
+++ b/Harmony/Internal/CodeTranspiler.cs
@@ -195,8 +195,13 @@ namespace HarmonyLib
 		{
 			var type = transpiler.GetParameters()
 				  .Select(p => p.ParameterType)
-				  .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition().Name.StartsWith("IEnumerable", StringComparison.Ordinal));
-			return ConvertInstructionsAndUnassignedValues(type, enumerable, out unassignedValues);
+				  .FirstOrDefault(t => IsTranspliterInstructionsParam(t));
+			return ConvertInstructionsAndUnassignedValues(type ?? typeof(IEnumerable<CodeInstruction>), enumerable, out unassignedValues);
+		}
+
+		internal static bool IsTranspliterInstructionsParam(Type paramType)
+		{
+			return paramType.IsGenericType && paramType.GetGenericTypeDefinition().Name.StartsWith("IEnumerable", StringComparison.Ordinal);
 		}
 
 		internal static List<object> GetTranspilerCallParameters(ILGenerator generator, MethodInfo transpiler, MethodBase method, IEnumerable instructions)
@@ -208,7 +213,7 @@ namespace HarmonyLib
 					parameter.Add(generator);
 				else if (type.IsAssignableFrom(typeof(MethodBase)))
 					parameter.Add(method);
-				else
+				else if (IsTranspliterInstructionsParam(type))
 					parameter.Add(instructions);
 			});
 			return parameter;

--- a/Harmony/Internal/MethodCopier.cs
+++ b/Harmony/Internal/MethodCopier.cs
@@ -63,16 +63,21 @@ namespace HarmonyLib
 			this.generator = generator;
 			this.method = method;
 			module = method.Module;
+			ilInstructions = new List<ILInstruction>();
 
 			var body = method.GetMethodBody();
-			if (body == null)
-				throw new ArgumentException("Method " + method.FullDescription() + " has no body");
-
-			var bytes = body.GetILAsByteArray();
-			if (bytes == null)
-				throw new ArgumentException("Can not get IL bytes of method " + method.FullDescription());
-			ilBytes = new ByteBuffer(bytes);
-			ilInstructions = new List<ILInstruction>((bytes.Length + 1) / 2);
+			if (body != null)
+			{
+				var bytes = body.GetILAsByteArray();
+				if(bytes == null)
+					throw new ArgumentException("Can not get IL bytes of method " + method.FullDescription());
+				ilBytes = new ByteBuffer(bytes);
+				ilInstructions.Capacity = (bytes.Length + 1) / 2;
+			}
+			else
+			{
+				ilBytes = new ByteBuffer(new byte[0]);
+			}
 
 			var type = method.DeclaringType;
 
@@ -92,8 +97,8 @@ namespace HarmonyLib
 				this_parameter = new ThisParameter(method);
 			parameters = method.GetParameters();
 
-			localVariables = body.LocalVariables?.ToList() ?? new List<LocalVariableInfo>();
-			exceptions = body.ExceptionHandlingClauses;
+			localVariables = body?.LocalVariables?.ToList() ?? new List<LocalVariableInfo>();
+			exceptions = body?.ExceptionHandlingClauses ?? new List<ExceptionHandlingClause>();
 		}
 
 		internal void ReadInstructions()

--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -476,6 +476,9 @@ namespace HarmonyLib
 			var canHaveJump = false;
 			prefixes.ForEach(fix =>
 			{
+				if (original.GetMethodBody() == null)
+					throw new Exception("Method without body cannot have prefix. Use transpiler instead.");
+
 				EmitCallParameter(il, original, fix, variables, false);
 				Emitter.Emit(il, OpCodes.Call, fix);
 
@@ -496,6 +499,9 @@ namespace HarmonyLib
 				.Where(fix => passthroughPatches == (fix.ReturnType != typeof(void)))
 				.Do(fix =>
 				{
+					if (original.GetMethodBody() == null)
+						throw new Exception("Method without body cannot have postfix. Use transpiler instead.");
+
 					EmitCallParameter(il, original, fix, variables, true);
 					Emitter.Emit(il, OpCodes.Call, fix);
 


### PR DESCRIPTION
This allows to patch invocations to `extern` P/Invoke methods, e.g. if a game uses native plugin.