### PR TITLE
Allow transpiler method parameter for the instructions IEnumerable be a ICollection, IList, or List

### DIFF
--- a/Harmony/Internal/CodeTranspiler.cs
+++ b/Harmony/Internal/CodeTranspiler.cs
@@ -194,8 +194,10 @@ namespace HarmonyLib
 		internal static IEnumerable ConvertToGeneralInstructions(MethodInfo transpiler, IEnumerable enumerable, out Dictionary<object, Dictionary<string, object>> unassignedValues)
 		{
 			var type = transpiler.GetParameters()
-				  .Select(p => p.ParameterType)
-				  .FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition().Name.StartsWith("IEnumerable", StringComparison.Ordinal));
+				.Select(p => p.ParameterType)
+				.FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition().Name is var name &&
+					(name.StartsWith("IEnumerable", StringComparison.Ordinal) || name.StartsWith("ICollection", StringComparison.Ordinal) ||
+					name.StartsWith("IList", StringComparison.Ordinal) || name.StartsWith("List", StringComparison.Ordinal)));
 			return ConvertInstructionsAndUnassignedValues(type, enumerable, out unassignedValues);
 		}
 

--- a/HarmonyTests/Patching/Transpiling.cs
+++ b/HarmonyTests/Patching/Transpiling.cs
@@ -21,8 +21,11 @@ namespace HarmonyLibTests.Patching
 		static readonly int codeLength = 61;
 #endif
 
-		[Test]
-		public void TestTranspilerException1()
+		[TestCase(nameof(TestTranspiler))]
+		[TestCase(nameof(TestTranspilerICollection))]
+		[TestCase(nameof(TestTranspilerIList))]
+		[TestCase(nameof(TestTranspilerList))]
+		public void TestTranspilerException1(string transpilerMethodName)
 		{
 			var test = new Class3();
 
@@ -32,7 +35,7 @@ namespace HarmonyLibTests.Patching
 			var original = AccessTools.Method(typeof(Class3), nameof(Class3.TestMethod));
 			Assert.IsNotNull(original);
 
-			var transpiler = AccessTools.Method(typeof(Transpiling), nameof(Transpiling.TestTranspiler));
+			var transpiler = AccessTools.Method(typeof(Transpiling), transpilerMethodName);
 			Assert.IsNotNull(transpiler);
 
 			var instance = new Harmony("test-exception1");
@@ -42,6 +45,7 @@ namespace HarmonyLibTests.Patching
 
 			test.TestMethod("restart");
 			Assert.AreEqual(test.GetLog, "restart,test,patch,ex:DivideByZeroException,finally,end");
+			instance.UnpatchAll("test-exception1");
 		}
 
 		public static IEnumerable<CodeInstruction> TestTranspiler(IEnumerable<CodeInstruction> instructions)
@@ -70,5 +74,11 @@ namespace HarmonyLibTests.Patching
 				yield return instruction;
 			}
 		}
+
+		public static IEnumerable<CodeInstruction> TestTranspilerICollection(ICollection<CodeInstruction> instructions) => TestTranspiler(instructions);
+
+		public static IEnumerable<CodeInstruction> TestTranspilerIList(IList<CodeInstruction> instructions) => TestTranspiler(instructions);
+
+		public static IEnumerable<CodeInstruction> TestTranspilerList(List<CodeInstruction> instructions) => TestTranspiler(instructions);
 	}
 }


### PR DESCRIPTION
I find myself almost always converting the IEnumerable<CodeInstruction> into a List<CodeInstruction> for access to the List methods like FindIndex, and from what I can tell of the harmony code, it's internally such a List anyway.

I generalized it to all the generic interfaces the List<T> implements.

Aside: I'm not sure how you get unit tests running yourself, but in order to run them via Visual Studio Test Explorer on all target frameworks (except for netcoreapp3.0), I had to locally remove the Microsoft.NET.Test.Sdk and NUnit3TestAdapter nugets, and install the NUnit 3 Test Adapter extension. Microsoft.NET.Test.Sdk requires netcoreapp2.1+ or net45+, while NUnit3TestAdapter requires netcoreapp1.0+, so they don't work for the .NET Framework versions like net35.