### PR TITLE
Fix rare MethodInvoker directBoxValueAccess=false bug where an inopportune GC can cause reboxed value address to become invalid

### DIFF
--- a/Harmony/Extras/MethodInvoker.cs
+++ b/Harmony/Extras/MethodInvoker.cs
@@ -65,21 +65,21 @@ namespace HarmonyLib
 					argType = argType.GetElementType();
 				var argIsValueType = argType.IsValueType;
 
-				// START DEBUG
-				//LocalBuilder boxedVar = null, reboxedVar = null;
-				//if (argIsByRef && argIsValueType && !directBoxValueAccess)
-				//{
-				//	// make sure the pinned void* local is declared first so it has local index 0
-				//	if (generateLocalBoxValuePtr)
-				//	{
-				//		generateLocalBoxValuePtr = false;
-				//		// Yes, you're seeing this right - a pinned local of type void* to store the box value address!
-				//		il.DeclareLocal(typeof(void*), true);
-				//	}
-				//	boxedVar = il.DeclareLocal(typeof(object), false);
-				//	reboxedVar = il.DeclareLocal(typeof(object), false);
-				//}
-				// END DEBUG
+#if TRACE
+				LocalBuilder boxedVar = null, reboxedVar = null;
+				if (argIsByRef && argIsValueType && !directBoxValueAccess)
+				{
+					// make sure the pinned void* local is declared first so it has local index 0
+					if (generateLocalBoxValuePtr)
+					{
+						generateLocalBoxValuePtr = false;
+						// Yes, you're seeing this right - a pinned local of type void* to store the box value address!
+						il.DeclareLocal(typeof(void*), true);
+					}
+					boxedVar = il.DeclareLocal(typeof(object), false);
+					reboxedVar = il.DeclareLocal(typeof(object), false);
+				}
+#endif
 
 				if (argIsByRef && argIsValueType && !directBoxValueAccess)
 				{
@@ -102,22 +102,23 @@ namespace HarmonyLib
 					{
 						if (!argIsByRef || !directBoxValueAccess)
 						{
-							// START DEBUG
-							//if (argIsByRef)
-							//{
-							//	il.Emit(OpCodes.Dup);
-							//	il.Emit(OpCodes.Stloc, boxedVar);
-							//	il.Emit(OpCodes.Dup);
-							//	il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
-							//	il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] boxed value pointer address (a)");
-							//	il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-							//	il.Emit(OpCodes.Dup);
-							//	il.Emit(OpCodes.Unbox, argType);
-							//	il.Emit(OpCodes.Conv_I8);
-							//	il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unboxed value pointer address (a)");
-							//	il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-							//}
-							// END DEBUG
+#if TRACE
+							if (argIsByRef)
+							{
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Stloc, boxedVar);
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] boxed value pointer address (a)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Unbox, argType);
+								il.Emit(OpCodes.Conv_I8);
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unboxed value pointer address (a)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+							}
+#endif
+
 							// if !directBoxValueAccess, create a new box if required
 							Emit(il, OpCodes.Unbox_Any, argType);
 							if (argIsByRef)
@@ -129,25 +130,25 @@ namespace HarmonyLib
 								// box back
 								Emit(il, OpCodes.Box, argType);
 
-								// START DEBUG
-								//il.Emit(OpCodes.Dup);
-								//il.Emit(OpCodes.Stloc_S, reboxedVar);
-								//il.Emit(OpCodes.Dup);
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reboxed value pointer address (a)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								// END DEBUG
+#if TRACE
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Stloc_S, reboxedVar);
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reboxed value pointer address (a)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+#endif
 
 								// store new box value address to local 0
 								Emit(il, OpCodes.Dup);
 								Emit(il, OpCodes.Unbox, argType);
 
-								// START DEBUG
-								//il.Emit(OpCodes.Dup);
-								//il.Emit(OpCodes.Conv_I8);
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unreboxed value pointer address (a)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								// END DEBUG
+#if TRACE
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Conv_I8);
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unreboxed value pointer address (a)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+#endif
 
 								if (generateLocalBoxValuePtr)
 								{
@@ -160,43 +161,41 @@ namespace HarmonyLib
 								// arr and index set up already
 								Emit(il, OpCodes.Stelem_Ref);
 
-								// START DEBUG
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] TryMoveAddressesViaGC");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(Out), AccessTools.all));
-								//il.Emit(OpCodes.Ldloc_S, boxedVar);
-								//il.Emit(OpCodes.Dup);
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] boxed value pointer address (b)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								//il.Emit(OpCodes.Unbox, argType);
-								//il.Emit(OpCodes.Conv_I8);
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unboxed value pointer address (b)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								//il.Emit(OpCodes.Ldarg_1);
-								//EmitFastInt(il, i);
-								//il.Emit(OpCodes.Ldelem_Ref);
-								//il.Emit(OpCodes.Dup);
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reboxed value pointer address (b1)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								//il.Emit(OpCodes.Unbox, argType);
-								//il.Emit(OpCodes.Conv_I8);
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reunboxed value pointer address (b1)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								//il.Emit(OpCodes.Ldloc_S, reboxedVar);
-								//il.Emit(OpCodes.Dup);
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reboxed value pointer address (b2)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								//il.Emit(OpCodes.Unbox, argType);
-								//il.Emit(OpCodes.Conv_I8);
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unreboxed value pointer address (b2)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								//il.Emit(OpCodes.Ldloc_0);
-								//il.Emit(OpCodes.Conv_I8);
-								//il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unreboxed value pointer address UNMANAGED (b)");
-								//il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
-								// END DEBUG
+#if TRACE
+								il.Emit(OpCodes.Ldloc_S, boxedVar);
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] boxed value pointer address (b)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Unbox, argType);
+								il.Emit(OpCodes.Conv_I8);
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unboxed value pointer address (b)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Ldarg_1);
+								il.Emit(OpCodes.Ldc_I4, i);
+								il.Emit(OpCodes.Ldelem_Ref);
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reboxed value pointer address (b1)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Unbox, argType);
+								il.Emit(OpCodes.Conv_I8);
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reunboxed value pointer address (b1)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Ldloc_S, reboxedVar);
+								il.Emit(OpCodes.Dup);
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(AddressOf), AccessTools.all));
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] reboxed value pointer address (b2)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Unbox, argType);
+								il.Emit(OpCodes.Conv_I8);
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unreboxed value pointer address (b2)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+								il.Emit(OpCodes.Ldloc_0);
+								il.Emit(OpCodes.Conv_I8);
+								il.Emit(OpCodes.Ldstr, $"[{i}:{ps[i].ParameterType}] unreboxed value pointer address UNMANAGED (b)");
+								il.Emit(OpCodes.Call, typeof(MethodInvoker).GetMethod(nameof(OutAddress), AccessTools.all));
+#endif
 
 								// load address back to stack
 								Emit(il, OpCodes.Ldloc_0);
@@ -233,9 +232,7 @@ namespace HarmonyLib
 			return (long)**(IntPtr**)(&tr);
 		}
 
-		static void OutAddress(long address, string label) => Out($"{label}: {address:X}");
-
-		static void Out(string str) => Console.WriteLine(str);
+		static void OutAddress(long address, string label) => Console.WriteLine($"{label}: {address:X}");
 
 		protected virtual void Emit(ILGenerator il, OpCode opcode) => il.Emit(opcode);
 

--- a/HarmonyTests/Extras/TestMethodInvoker.cs
+++ b/HarmonyTests/Extras/TestMethodInvoker.cs
@@ -19,7 +19,7 @@ namespace HarmonyLibTests
 			Assert.IsNotNull(method);
 
 			var methodInvoker = gcHell ? new MethodInvokerGCHell(directBoxValueAccess) : new MethodInvoker(directBoxValueAccess);
-			var handler = methodInvoker.GetHandler(method, method.DeclaringType.Module);
+			var handler = methodInvoker.Handler(method, method.DeclaringType.Module);
 			Assert.IsNotNull(handler);
 
 			var testStruct = new TestMethodInvokerStruct();

--- a/HarmonyTests/Extras/TestMethodInvoker.cs
+++ b/HarmonyTests/Extras/TestMethodInvoker.cs
@@ -74,9 +74,6 @@ namespace HarmonyLibTests
 			GC.AddMemoryPressure(memoryPressureBytesAllocated);
 			GC.Collect();
 			GC.RemoveMemoryPressure(memoryPressureBytesAllocated);
-#if TRACE
-			Console.WriteLine("TryMoveAddressesViaGC");
-#endif
 		}
 
 		static readonly MethodInfo tryMoveAddressesViaGCMethod = typeof(MethodInvokerGCHell).GetMethod(nameof(TryMoveAddressesViaGC), AccessTools.all);

--- a/HarmonyTests/Extras/TestMethodInvoker.cs
+++ b/HarmonyTests/Extras/TestMethodInvoker.cs
@@ -7,24 +7,34 @@ namespace HarmonyLibTests
 	[TestFixture]
 	public class TestMethodInvoker
 	{
-		[Test]
-		public void TestMethodInvokerGeneral()
+		[TestCase(false)]
+		[TestCase(true)]
+		public void TestMethodInvokerGeneral(bool directBoxValueAccess)
 		{
 			var type = typeof(MethodInvokerClass);
 			Assert.IsNotNull(type);
 			var method = type.GetMethod("Method1");
 			Assert.IsNotNull(method);
 
-			var handler = MethodInvoker.GetHandler(method);
+			var handler = MethodInvoker.GetHandler(method, method.DeclaringType.Module, directBoxValueAccess);
 			Assert.IsNotNull(handler);
 
-			var args = new object[] { 1, 0, 0, /*out*/ null, /*ref*/ new TestMethodInvokerStruct() };
-			handler(null, args);
-			Assert.AreEqual(args[0], 1);
-			Assert.AreEqual(args[1], 1);
-			Assert.AreEqual(args[2], 2);
-			Assert.AreEqual(((TestMethodInvokerObject)args[3])?.Value, 1);
-			Assert.AreEqual(((TestMethodInvokerStruct)args[4]).Value, 1);
+			var testStruct = new TestMethodInvokerStruct();
+			var boxedTestStruct = (object)testStruct;
+			var args = new object[] { 0, 0, 0, /*out*/ null, /*ref*/ boxedTestStruct };
+			for (var a = 0; a < 100; a++)
+			{
+				args[0] = a;
+				var b = (int)args[1];
+				handler(null, args);
+				Assert.AreEqual(a, args[0], "@a={0}", a);
+				Assert.AreEqual(b + 1, args[1], "@a={0}", a);
+				Assert.AreEqual((b + 1) * 2, args[2], "@a={0}", a);
+				Assert.AreEqual(a, ((TestMethodInvokerObject)args[3])?.Value, "@a={0}", a);
+				Assert.AreEqual(a, ((TestMethodInvokerStruct)args[4]).Value, "@a={0}", a);
+				Assert.AreEqual(0, testStruct.Value, "@a={0}", a);
+				Assert.AreEqual(directBoxValueAccess ? a : 0, ((TestMethodInvokerStruct)boxedTestStruct).Value, "@a={0}", a);
+			}
 		}
 
 		[Test]
@@ -45,7 +55,7 @@ namespace HarmonyLibTests
 
 			var args = new object[] { 2 };
 			handler(instance, args);
-			Assert.AreEqual(instance.Value, 3);
+			Assert.AreEqual(3, instance.Value);
 		}
 	}
 }

--- a/HarmonyTests/Extras/TestMethodInvoker.cs
+++ b/HarmonyTests/Extras/TestMethodInvoker.cs
@@ -11,7 +11,7 @@ namespace HarmonyLibTests
 	public class TestMethodInvoker
 	{
 		[Test]
-		public void TestMethodInvokerGeneral([Values(false, true)] bool directBoxValueAccess, [Values(false, true)] bool gcHell)
+		public void TestMethodInvokerGeneral([Values(false, true)] bool directBoxValueAccess, [Values(false, true)] bool gcHell, [Values(100)] int iterations)
 		{
 			var type = typeof(MethodInvokerClass);
 			Assert.IsNotNull(type);
@@ -25,7 +25,7 @@ namespace HarmonyLibTests
 			var testStruct = new TestMethodInvokerStruct();
 			var boxedTestStruct = (object)testStruct;
 			var args = new object[] { 0, 0, 0, /*out*/ null, /*ref*/ boxedTestStruct };
-			for (var a = 0; a < 100; a++)
+			for (var a = 0; a < iterations; a++)
 			{
 				args[0] = a;
 				var b = (int)args[1];
@@ -74,6 +74,9 @@ namespace HarmonyLibTests
 			GC.AddMemoryPressure(memoryPressureBytesAllocated);
 			GC.Collect();
 			GC.RemoveMemoryPressure(memoryPressureBytesAllocated);
+#if TRACE
+			Console.WriteLine("TryMoveAddressesViaGC");
+#endif
 		}
 
 		static readonly MethodInfo tryMoveAddressesViaGCMethod = typeof(MethodInvokerGCHell).GetMethod(nameof(TryMoveAddressesViaGC), AccessTools.all);


### PR DESCRIPTION
## Background
Some background, continuing from the discussion on discord:

I was curious as to how and why the `directBoxValueAccess=false` logic in `MethodInvoker` works for by-ref value types. I learned the whole point of this mode is to avoid directly updating the boxed value in the arguments array, which could which be reflected in all existing references to that boxed value (not just in the arguments array), and to instead replace that boxed value in the arguments array with a "reboxed" value, such that updates to the boxed value are instead localized only to this reboxed value.

To illustrate the difference:
```cs
public static void TimesTwo(ref int x) => x *= 2;
...
var method = GetType().GetMethod(nameof(TimesTwo));
var handler = MethodInvoker.Handler(method, method.DeclaringType.Module, directBoxValueAccess);

var boxedValue = (object)1000;
var args = new object[] { boxedValue };
handler(null, args);
Assert.AreEqual(2000, (int)args[0]);
Assert.AreEqual(directBoxValueAccess ? 2000 : 1000, (int)boxedValue);
```

One of the techniques used in `directBoxValueAccess=false` mode is to store the address of the unboxed value into a "pinned" unmanaged `void*` pointer. The point of this is to avoid need to create local variables for each by-ref value type, in favor of a single local. It's pinned to ensure that unboxed value that it points to doesn't change its address (via garbage collections), which would invalidate an unmanaged pointer.

## Problem

This doesn't work however. Unmanaged pointer locals apparently can't be directly pinned. Rather, there needs to a managed reference local that's pinned, and the unmanaged pointer needs have an address at/within the data this managed reference refers to.

For example, the following:
```cs
struct S { ... }
...
void Foo()
{
	var arr = new S[] { new S() };
	unsafe
	{
		fixed (void* ptr = &arr[0]) { ... }
	}
}
```
generates the following locals for `Foo`:
```
.locals init (
	[0] valuetype S[],
	[1] valuetype S& pinned,
	[2] void*
)
```
Notice how `arr[0]` is effectively assigned to a pinned local of type `S&`, and that the local of type `void*` isn't pinned at all.

Another note: Managed references (like `<type>&` and object locals) and managed pointers (like the result of the `unbox` instruction) have internal pointers to the actual memory addresses that are automatically updated if the data at those memory addresses are moved (via garbage collections). The notion of pinning is only required within "unmanaged" code (which includes the usage of unmanaged pointers like this `void*` local).

In practice, it's likely extremely rare, and perhaps impossible on some .NET runtimes, for the memory address of the reboxed value to change between its creation (during the setting up of the method invocation arguments) and the method invocation, but I've confirmed with tests that it's technically possible.

## Solution

A potential solution is to add an additional pinned local for `<valuetype>&`, i.e. managed reference for the value type, but since it's type-specific, it would result in multiple locals, defeating the purpose of the single `void*` local.

Rather than pinned locals for `<valuetype>&`, how about a generic pinned local for the boxed value? The boxed value is always an object, so we only need a single pinned local of type `object` for this to work.

That works. But if we now have a single local that stores the boxed object, we actually no longer need that single `void*` local. Just store the reboxed object in this boxed object local, update the argument array with the reboxed object as usual, load the reboxed object, then `unbox` it.

Furthermore, if we get rid of the `void*` local, we no longer have an unmanaged pointer, and thus the local for the boxed object doesn't need to be pinned at all.

Of course, if the method being invoked is itself unmanaged code, then yes, the local would have to be pinned. But that applies to *all* pointer arguments to such a method - all pointer arguments, regardless of whether it's a value type or not, would need to be stored in pinned locals. Since `MethodInvoker` isn't doing that, the implicit assumption is that the method being invoked is either not unmanaged code, or doesn't access any managed references that `MethodInvoker` could be aware of.

## Code change notes

To discover the above problem, I had to put together a test that shows it. I did this by make `MethodInvoker` subclassable, and having a test subclass of `MethodInvoker` (named `MethodInvokerGCHell`) that interweaves in instruction `call`s to a `TryMoveAddressesViaGC` method that triggers GCs in a way that should compact the heap and thus move data to different memory addresses:
```cs
		static void TryMoveAddressesViaGC()
		{
			var memoryPressureBytesAllocated = 100000000;
			GC.AddMemoryPressure(memoryPressureBytesAllocated);
			GC.Collect();
			GC.RemoveMemoryPressure(memoryPressureBytesAllocated);
		}
```

The tests are run under the following scenarios:
1. `directBoxValueAccess=false`, use normal `MethodInvoker`
2. `directBoxValueAccess=true`, use normal `MethodInvoker`
3. `directBoxValueAccess=false`, use test `MethodInvokerGCHell`
4. `directBoxValueAccess=true`, use test `MethodInvokerGCHell` (fails before the fix)

I also added a bunch of `#if TRACE`-guarded debugging code. As they do clutter up the code, I can remove them upon request.