### PR TITLE
Update nugets, try updating CI to run tests for all target frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 
 jobs:
   allow_failures:
-    # unit tests for netcoreapp3.0 currently fail
+    # TODO: Remove this when netcoreapp3.0 works and unit tests for it succeed.
     - env: netframework=netcoreapp3.0
   exclude:
     # dotnet test (specifically, .NET Core itself) currently doesn't work with .NET Framework 3.5, so have to use mono + nunit3-console.exe (see include below)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,82 @@
-dist: xenial
-addons:
-  snaps:
-  - name: dotnet-sdk
-    classic: true
-    channel: latest/beta
-sudo: required
+# Note: Even though dotnet test works in .NET Framework 4+, it apparently still requires mono.
+# dotnet test currently doesn't work for .NET Framework 3.5, because Microsoft.NETFramework.ReferenceAssemblies
+# doesn't have a build for it yet: https://github.com/dotnet/core-sdk/issues/2022
+# Also, builds that use mono are currently very slow due to https://github.com/travis-ci/travis-ci/issues/4571
+
 language: csharp
+solution: Harmony.sln
+
 os:
   - linux
   - osx
-solution: Harmony.sln
+
+env:
+  - netframework=net35
+  - netframework=net45
+  - netframework=net472
+  - netframework=net48
+  - netframework=netcoreapp3.0
+
 mono:
-  - latest
-dotnet: 2.0.3
+- latest
+- none
+
+# "dotnet: 3.0" works fine for linux, but osx needs the exact version for some reason.
+dotnet: 3.0.100
+
 before_install:
   - if [ "$TRAVIS_COMMIT_MESSAGE" == "Update documentation" ]; then echo "Skipping documentation only commit" && exit; fi
+
 install:
-  - nuget restore
-  - dotnet restore
-  - nuget install NUnit.Console -Version 3.9.0 -OutputDirectory testrunner
-script:
-  - sudo snap alias dotnet-sdk.dotnet dotnet
   - dotnet --version
-  - msbuild /p:Configuration=Release
-  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe HarmonyTests/bin/Release/net45/HarmonyTests.dll
+  - dotnet restore
+
+script:
+  - dotnet build --framework ${netframework}
+  - mkdir ~/Desktop # some unit tests log to ~/Desktop/harmony.log.txt
+  - dotnet test HarmonyTests --framework ${netframework}
+
+jobs:
+  allow_failures:
+    # unit tests for netcoreapp3.0 currently fail
+    - env: netframework=netcoreapp3.0
+  exclude:
+    # dotnet test (specifically, .NET Core itself) currently doesn't work with .NET Framework 3.5, so have to use mono + nunit3-console.exe (see include below)
+    - env: netframework=net35
+    # We can use dotnet test with .NET Framework 4+, but it apparently still requires mono on non-Windows machines
+    # (otherwise, dotnet (vs)test outputs this error: Could not find 'mono' host. Make sure that 'mono' is installed on the machine and is available in PATH environment variable.)
+    - env: netframework=net45
+      mono: none
+    - env: netframework=net472
+      mono: none
+    - env: netframework=net48
+      mono: none
+    # nunit3-console.exe doesn't work with netcoreapp* target frameworks, so must use dotnet test
+    - env: netframework=netcoreapp3.0
+      mono: latest
+  include:
+    - os: linux
+      env: netframework=net35
+      mono: latest
+      install:
+        - dotnet --version
+        - dotnet restore
+        - nuget install NUnit.Console -OutputDirectory testrunner
+      script:
+        - msbuild /p:Configuration=Release /p:TargetFrameworks=${netframework}
+        - mkdir ~/Desktop # some unit tests log to ~/Desktop/harmony.log.txt
+        - mono ./testrunner/NUnit.ConsoleRunner.*/tools/nunit3-console.exe HarmonyTests/bin/Release/${netframework}/HarmonyTests.dll --inprocess
+    - os: osx
+      env: netframework=net35
+      mono: latest
+      install:
+        - dotnet --version
+        - dotnet restore
+        - nuget install NUnit.Console -OutputDirectory testrunner
+      script:
+        - msbuild /p:Configuration=Release /p:TargetFrameworks=${netframework}
+        - mkdir ~/Desktop # some unit tests log to ~/Desktop/harmony.log.txt
+        - mono ./testrunner/NUnit.ConsoleRunner.*/tools/nunit3-console.exe HarmonyTests/bin/Release/${netframework}/HarmonyTests.dll --inprocess
+
 notifications:
   email: false

--- a/Harmony.sln
+++ b/Harmony.sln
@@ -1,13 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29509.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{887FC7DA-9A29-4130-92E7-66E21E76CAC4}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
+		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Harmony", "Harmony\Harmony.csproj", "{69AEE16A-B6E7-4642-8081-3928B32455DF}"

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -46,17 +46,8 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net35|AnyCPU'">
-    <OutputPath></OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net35|AnyCPU'">
-  </PropertyGroup>
-
-  <ProjectExtensions>
-    <VisualStudio>
-      <UserProperties />
-    </VisualStudio>
-  </ProjectExtensions>
+  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
 
 </Project>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -30,6 +30,10 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Harmony\Harmony.csproj" />
   </ItemGroup>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net35;net45;net472;net48;netcoreapp3.0</TargetFrameworks>
@@ -25,9 +25,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HarmonyTests/IL/DynamicArgumentPatches.cs
+++ b/HarmonyTests/IL/DynamicArgumentPatches.cs
@@ -181,6 +181,7 @@ namespace HarmonyLibTests.IL
 			SymbolExtensions.GetMethodInfo(() => TestMethods3.Test3(Vec3.Zero, null))
 		};
 
+		// TODO: Investigate why this is failing for CI linux/OSX builds - see error in https://github.com/pardeike/Harmony/pull/221
 		[Test]
 		public void SendingArguments()
 		{

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,44 @@
 version: 1.0.{build}
 
-#########################################################################
-### TODO: this fails because AppVeyor has no Visual Studio 2019 image yet
-#########################################################################
-
 max_jobs: 1
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 
+environment:
+  matrix:
+    - targetframework: net35
+    - targetframework: net45
+    - targetframework: net472
+    - targetframework: net48
+    - targetframework: netcoreapp3.0
+
 before_build:
-- nuget restore
+- dotnet --version
 - dotnet restore
+
+matrix:
+  allow_failures:
+    # unit tests for netcoreapp3.0 currently fail
+    - targetframework: netcoreapp3.0
+
+for:
+  -
+    # dotnet test currently doesn't work for .NET Framework 3.5, because Microsoft.NETFramework.ReferenceAssemblies
+    # doesn't have a build for it yet: https://github.com/dotnet/core-sdk/issues/2022
+    matrix:
+      only:
+        - targetframework: net35
+    test_script:
+      - cmd: nunit3-console.exe HarmonyTests/bin/Release/%targetframework%/HarmonyTests.dll --inprocess --result=results.xml;format=AppVeyor
+  -
+    matrix:
+      except:
+        - targetframework: net35
+    test_script:
+    - cmd: cd HarmonyTests
+    - cmd: nuget install Appveyor.TestLogger -Version 2.0.0
+    - cmd: cd ..
+    - cmd: dotnet test HarmonyTests --framework %targetframework% --test-adapter-path:. --logger:Appveyor
 
 artifacts:
 - path: 'Harmony\bin\Release\Lib.Harmony.*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ before_build:
 
 matrix:
   allow_failures:
-    # unit tests for netcoreapp3.0 currently fail
+    # TODO: Remove this when netcoreapp3.0 works and unit tests for it succeed.
     - targetframework: netcoreapp3.0
 
 for:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'VS2017-Win2016'
+  vmImage: 'windows-latest'
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
1. Update nugets to latest versions
2. Add Microsoft.NETFramework.ReferenceAssemblies nuget dependency for non-Windows builds
3. Update appveyor config:
    1. Use 'Visual Studio 2019' image
    2. Run dotnet test for all target frameworks except .NET Framework 3.5
    3. Run nunit3-console for .NET Framework 3.5 with --inprocess flag, because Microsoft.NETFramework.ReferenceAssemblies doesn't include a build for .NET Framework 3.5 yet
4. Update travis config:
    1. Use dotnet 3.0 and latest nunit3-console nuget
    2. Run dotnet test for all target frameworks except .NET Framework 3.5
    3. Run nunit3-console for .NET Framework 3.5 with --inprocess flag, because Microsoft.NETFramework.ReferenceAssemblies doesn't include a build for .NET Framework 3.5 yet
5. Update azure-pipelines to use 'windows-latest' image, but although it now doesn't fail, it still does practically nothing as far as I can tell