### PR TITLE
Fix remaining unit testing issues (excluding netcoreapp3.0 issues)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
 
 script:
   - dotnet build --framework ${netframework}
-  - mkdir ~/Desktop # some unit tests log to ~/Desktop/harmony.log.txt
   - dotnet test HarmonyTests --framework ${netframework}
 
 jobs:
@@ -64,7 +63,6 @@ jobs:
         - nuget install NUnit.Console -OutputDirectory testrunner
       script:
         - msbuild /p:Configuration=Release /p:TargetFrameworks=${netframework}
-        - mkdir ~/Desktop # some unit tests log to ~/Desktop/harmony.log.txt
         - mono ./testrunner/NUnit.ConsoleRunner.*/tools/nunit3-console.exe HarmonyTests/bin/Release/${netframework}/HarmonyTests.dll --inprocess
     - os: osx
       env: netframework=net35
@@ -75,7 +73,6 @@ jobs:
         - nuget install NUnit.Console -OutputDirectory testrunner
       script:
         - msbuild /p:Configuration=Release /p:TargetFrameworks=${netframework}
-        - mkdir ~/Desktop # some unit tests log to ~/Desktop/harmony.log.txt
         - mono ./testrunner/NUnit.ConsoleRunner.*/tools/nunit3-console.exe HarmonyTests/bin/Release/${netframework}/HarmonyTests.dll --inprocess
 
 notifications:

--- a/HarmonyTests/IL/DynamicArgumentPatches.cs
+++ b/HarmonyTests/IL/DynamicArgumentPatches.cs
@@ -107,7 +107,8 @@ namespace HarmonyLibTests.IL
 
 			yield return new CodeInstruction(OpCodes.Ldstr, original.DeclaringType.FullName);
 			yield return new CodeInstruction(OpCodes.Ldc_I4, original.MetadataToken);
-			yield return new CodeInstruction(original.IsStatic ? OpCodes.Ldc_I4_0 : OpCodes.Ldarg_0);
+			// Note: While some .NET runtimes allow representing 0 (via ldc.i*.0) as null, at least mono doesn't allow that - just use ldnull instead.
+			yield return new CodeInstruction(original.IsStatic ? OpCodes.Ldnull : OpCodes.Ldarg_0);
 
 			yield return new CodeInstruction(OpCodes.Ldc_I4, parameter.Length);
 			yield return new CodeInstruction(OpCodes.Newarr, typeof(object));
@@ -181,7 +182,6 @@ namespace HarmonyLibTests.IL
 			SymbolExtensions.GetMethodInfo(() => TestMethods3.Test3(Vec3.Zero, null))
 		};
 
-		// TODO: Investigate why this is failing for CI linux/OSX builds - see error in https://github.com/pardeike/Harmony/pull/221
 		[Test]
 		public void SendingArguments()
 		{

--- a/HarmonyTests/IL/DynamicArgumentPatches.cs
+++ b/HarmonyTests/IL/DynamicArgumentPatches.cs
@@ -185,7 +185,7 @@ namespace HarmonyLibTests.IL
 		[Test]
 		public void SendingArguments()
 		{
-			Harmony.DEBUG = true;
+			//Harmony.DEBUG = true;
 			var harmony = new Harmony("test");
 			methods.Do(m =>
 			{

--- a/HarmonyTests/ReversePatching/AttributeReversePatches.cs
+++ b/HarmonyTests/ReversePatching/AttributeReversePatches.cs
@@ -15,7 +15,7 @@ namespace HarmonyLibTests
 			var result1 = test.Method("Foo", 123);
 			Assert.AreEqual("FooExtra123", result1);
 
-			Harmony.DEBUG = true;
+			//Harmony.DEBUG = true;
 			var instance = new Harmony("test");
 			Assert.IsNotNull(instance);
 

--- a/HarmonyTests/ReversePatching/ReverseTranspiling.cs
+++ b/HarmonyTests/ReversePatching/ReverseTranspiling.cs
@@ -24,7 +24,7 @@ namespace HarmonyLibTests
 			var postfix = patchClass.GetMethod("Postfix");
 			Assert.IsNotNull(postfix);
 
-			Harmony.DEBUG = true;
+			//Harmony.DEBUG = true;
 			var instance = new Harmony("test");
 			Assert.IsNotNull(instance);
 


### PR DESCRIPTION
* Fix DynamicArgumentPatches.SendingArguments unit test on mono (see #221 for the error)
* Don't enable Harmony.DEBUG in unit tests, allow linux CI to fail if it is enabled