### PR TITLE
Make Traverse.Property, Traverse.Field and Traverse.Method behavior uniform

### DIFF
--- a/Harmony/Internal/AccessCache.cs
+++ b/Harmony/Internal/AccessCache.cs
@@ -19,7 +19,7 @@ namespace HarmonyLib
 			}
 			if (fieldsByType.TryGetValue(name, out var field) == false)
 			{
-				field = AccessTools.DeclaredField(type, name);
+				field = AccessTools.Field(type, name);
 				fieldsByType.Add(name, field);
 			}
 			return field;
@@ -34,7 +34,7 @@ namespace HarmonyLib
 			}
 			if (propertiesByType.TryGetValue(name, out var property) == false)
 			{
-				property = AccessTools.DeclaredProperty(type, name);
+				property = AccessTools.Property(type, name);
 				propertiesByType.Add(name, property);
 			}
 			return property;

--- a/Harmony/Tools/Traverse.cs
+++ b/Harmony/Tools/Traverse.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -269,9 +270,10 @@ namespace HarmonyLib
 		{
 			if (name == null) throw new ArgumentNullException(nameof(name));
 			var resolved = Resolve();
-			if (resolved._root == null || resolved._type == null) return new Traverse();
+			if (resolved._type == null) return new Traverse();
 			var info = Cache.GetPropertyInfo(resolved._type, name);
 			if (info == null) return new Traverse();
+			if (info.GetAccessors(true).First().IsStatic == false && resolved._root == null) return new Traverse();
 			return new Traverse(resolved._root, info, index);
 		}
 

--- a/HarmonyTests/Traverse/Assets/TraverseProperties_AccessModifiers.cs
+++ b/HarmonyTests/Traverse/Assets/TraverseProperties_AccessModifiers.cs
@@ -19,7 +19,7 @@ namespace HarmonyLibTests.Assets
 		}
 
 		string _basePropertyField2;
-		protected virtual string BaseProperty2
+		protected string BaseProperty2
 		{
 			get => _basePropertyField2;
 			set => _basePropertyField2 = value;

--- a/HarmonyTests/Traverse/TestTraverse_Properties.cs
+++ b/HarmonyTests/Traverse/TestTraverse_Properties.cs
@@ -14,8 +14,11 @@ namespace HarmonyLibTests
 		{
 			var instance = new TraverseProperties_AccessModifiers(TraverseProperties.testStrings);
 
-			var trv = Traverse.Create(instance).Property(TraverseProperties.propertyNames[0]);
-			Assert.AreEqual(TraverseProperties.testStrings[0], trv.ToString());
+			for (var i = 0; i < TraverseProperties.testStrings.Length; i++)
+			{
+				var trv = Traverse.Create(instance).Property(TraverseProperties.propertyNames[i]);
+				Assert.AreEqual(TraverseProperties.testStrings[i], trv.ToString());
+			}
 		}
 
 		// Traverse.GetValue() should return the value of a traversed property
@@ -32,17 +35,8 @@ namespace HarmonyLibTests
 				var name = TraverseProperties.propertyNames[i];
 				var ptrv = trv.Property(name);
 				Assert.IsNotNull(ptrv);
-				if (name == "BaseProperty2")
-				{
-					// BaseProperty2 is only defined in base class
-					Assert.IsNull(ptrv.GetValue());
-					Assert.IsNull(ptrv.GetValue<string>());
-				}
-				else
-				{
-					Assert.AreEqual(TraverseProperties.testStrings[i], ptrv.GetValue());
-					Assert.AreEqual(TraverseProperties.testStrings[i], ptrv.GetValue<string>());
-				}
+				Assert.AreEqual(TraverseProperties.testStrings[i], ptrv.GetValue());
+				Assert.AreEqual(TraverseProperties.testStrings[i], ptrv.GetValue<string>());
 			}
 		}
 
@@ -68,19 +62,9 @@ namespace HarmonyLibTests
 				ptrv.SetValue(newValue);
 
 				// after
-				if (name == "BaseProperty2")
-				{
-					// BaseProperty2 is only defined in base class
-					Assert.AreEqual(TraverseProperties.testStrings[i], instance.GetTestProperty(i));
-					Assert.IsNull(ptrv.GetValue());
-					Assert.IsNull(ptrv.GetValue<string>());
-				}
-				else
-				{
-					Assert.AreEqual(newValue, instance.GetTestProperty(i));
-					Assert.AreEqual(newValue, ptrv.GetValue());
-					Assert.AreEqual(newValue, ptrv.GetValue<string>());
-				}
+				Assert.AreEqual(newValue, instance.GetTestProperty(i));
+				Assert.AreEqual(newValue, ptrv.GetValue());
+				Assert.AreEqual(newValue, ptrv.GetValue<string>());
 			}
 		}
 	}


### PR DESCRIPTION
Made traverse detect static and non-declared properties, as well as non-declared fields (static fields were already detected). This makes `Traverse.Field` and `Traverse.Property` work the same way as `Traverse.Method`.

Fixes issues #215 and #213.