### PR TITLE
Fix MethodBodyReader throwing error when parsing local var operand and no generator

### DIFF
--- a/Harmony/Internal/MethodCopier.cs
+++ b/Harmony/Internal/MethodCopier.cs
@@ -561,7 +561,7 @@ namespace HarmonyLib
 							else
 							{
 								instruction.operand = lvi;
-								instruction.argument = variables[lvi.LocalIndex];
+								instruction.argument = variables?[lvi.LocalIndex] ?? lvi;
 							}
 						}
 						else
@@ -583,7 +583,7 @@ namespace HarmonyLib
 							else
 							{
 								instruction.operand = lvi;
-								instruction.argument = variables[lvi.LocalIndex];
+								instruction.argument = variables?[lvi.LocalIndex] ?? lvi;
 							}
 						}
 						else

--- a/HarmonyTests/IL/TestMethodBodyReader.cs
+++ b/HarmonyTests/IL/TestMethodBodyReader.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using HarmonyLibTests.Assets;
+using NUnit.Framework;
+
+namespace HarmonyLibTests.IL
+{
+	[TestFixture]
+	public class TestMethodBodyReader
+	{
+		[Test]
+		public void CanGetInstructionsWithNoILGenerator()
+		{
+			var method = typeof(Class12).GetMethod(nameof(Class12.FizzBuzz));
+			var instrsNoGen = MethodBodyReader.GetInstructions(generator: null, method);
+
+			var dynamicMethod = DynamicTools.CreateDynamicMethod(method, "_Patch");
+			var instrsHasGen = MethodBodyReader.GetInstructions(dynamicMethod.GetILGenerator(), method);
+
+			Assert.AreEqual(instrsNoGen.Count, instrsHasGen.Count);
+			for (var i = 0; i < instrsNoGen.Count; i++)
+			{
+				var instrNoGen = instrsNoGen[i];
+				var instrHasGen = instrsHasGen[i];
+				Assert.AreEqual(instrNoGen.offset, instrHasGen.offset, "offset @ {0} ({1})", i, instrNoGen);
+				Assert.AreEqual(instrNoGen.opcode, instrHasGen.opcode, "opcode @ {0} ({1})", i, instrNoGen);
+				AssertAreEqual(instrNoGen.operand, instrHasGen.operand, "operand", i, instrNoGen);
+				CollectionAssert.AreEqual(instrNoGen.labels, instrHasGen.labels, "labels @ {0}", i);
+				CollectionAssert.AreEqual(instrNoGen.blocks, instrHasGen.blocks, "blocks @ {0}", i);
+				AssertAreEqual(instrNoGen.operand, instrHasGen.operand, "argument", i, instrNoGen);
+
+				// The only difference between w/o gen and w/ gen is this:
+				var operandType = instrNoGen.opcode.OperandType;
+				if ((operandType == OperandType.ShortInlineVar || operandType == OperandType.InlineVar) && !(instrNoGen.argument is null))
+				{
+					Assert.AreEqual(typeof(LocalVariableInfo), instrNoGen.argument.GetType(), "w/o generator argument type @ {0} ({1})", i, instrNoGen);
+					Assert.AreEqual(typeof(LocalBuilder), instrHasGen.argument.GetType(), "w/ generator argument type @ {0} ({1})", i, instrNoGen);
+				}
+			}
+		}
+
+		static void AssertAreEqual(object x, object y, string label, int currentIndex, ILInstruction currentInstr)
+		{
+			if (x is ILInstruction xInstr && y is ILInstruction yInstr)
+				Assert.AreEqual(xInstr.offset, yInstr.offset, "{0} @ {1} ({2})", label, currentIndex, currentInstr);
+			else if (x is ILInstruction[] xInstrs && y is ILInstruction[] yInstrs)
+				CollectionAssert.AreEqual(xInstrs, yInstrs, new ILInstructionOffsetComparer(), "{0} @ {1} ({2})", label, currentIndex, currentInstr);
+			else if (x is LocalVariableInfo xLocal && y is LocalVariableInfo yLocal)
+				AssertAreEqual(xLocal, yLocal, label, currentIndex, currentInstr);
+			else
+				Assert.AreEqual(x, y, "{0} @ {1} ({2})", label, currentIndex, currentInstr);
+		}
+
+		static void AssertAreEqual(LocalVariableInfo x, LocalVariableInfo y, string label, int currentIndex, ILInstruction currentInstr)
+		{
+			Assert.AreEqual(x.LocalType, y.LocalType, "{0}.{1} @ {2} ({3})", label, "LocalType", currentIndex, currentInstr);
+			Assert.AreEqual(x.IsPinned, y.IsPinned, "{0}.{1} @ {2} ({3})", label, "IsPinned", currentIndex, currentInstr);
+			Assert.AreEqual(x.LocalIndex, y.LocalIndex, "{0}.{1} @ {2} ({3})", label, "LocalIndex", currentIndex, currentInstr);
+		}
+
+		struct ILInstructionOffsetComparer : IComparer
+		{
+			public int Compare(object x, object y) => ((ILInstruction)x).offset.CompareTo(((ILInstruction)y).offset);
+		}
+	}
+}

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -553,6 +553,30 @@ namespace HarmonyLibTests.Assets
 		}
 	}
 
+	public class Class12
+	{
+		readonly int count;
+
+		public Class12(int count) => this.count = count;
+
+		public List<string> FizzBuzz()
+		{
+			var output = new List<string>(count);
+			for (var i = 1; i <= count; i++)
+			{
+				if (i % 15 == 0)
+					output.Add("FizzBuzz");
+				else if (i % 3 == 0)
+					output.Add("Fizz");
+				else if (i % 5 == 0)
+					output.Add("Buzz");
+				else
+					output.Add(i.ToString());
+			}
+			return output;
+		}
+	}
+
 	// disabled - see test case
 	/*
 	public class ClassExceptionFilter


### PR DESCRIPTION
Fix MethodBodyReader throwing error when parsing local var operand and no generator.

Add unit test.

In the future, there should be a way to publicly expose this functionality (something like `List<CodeInstruction> GetMethodInstructions(MethodBase method)`) along with caching.