### PR TITLE
dotnet build now works cross-platform (but not dotnet test), misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # Note: Even though dotnet test works in .NET Framework 4+, it apparently still requires mono.
-# dotnet test currently doesn't work for .NET Framework 3.5, because Microsoft.NETFramework.ReferenceAssemblies
-# doesn't have a build for it yet: https://github.com/dotnet/core-sdk/issues/2022
+# dotnet test currently doesn't work for .NET Framework 3.5, because:
+# 1) Microsoft.NETFramework.ReferenceAssemblies doesn't have a build for it yet: https://github.com/dotnet/core-sdk/issues/2022
+#    (this has been addressed using workaround mentioned in that issue).
+# 2) dotnet test doesn't recognize .NET Framework 3.5 as a valid test project (does not set IsTestProject property for it).
+# 3) Even if the above are worked around, dotnet test shows:
+#    Framework35 is not supported. For projects targeting .Net Framework 3.5, test will run in CLR 4.0 "compatibility mode".
 # Also, builds that use mono are currently very slow due to https://github.com/travis-ci/travis-ci/issues/4571
 
 language: csharp

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -46,8 +46,9 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -30,8 +30,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HarmonyTests/IL/TestMethodBodyReader.cs
+++ b/HarmonyTests/IL/TestMethodBodyReader.cs
@@ -29,7 +29,7 @@ namespace HarmonyLibTests.IL
 				AssertAreEqual(instrNoGen.operand, instrHasGen.operand, "operand", i, instrNoGen);
 				CollectionAssert.AreEqual(instrNoGen.labels, instrHasGen.labels, "labels @ {0}", i);
 				CollectionAssert.AreEqual(instrNoGen.blocks, instrHasGen.blocks, "blocks @ {0}", i);
-				AssertAreEqual(instrNoGen.operand, instrHasGen.operand, "argument", i, instrNoGen);
+				AssertAreEqual(instrNoGen.argument, instrHasGen.argument, "argument", i, instrNoGen);
 
 				// The only difference between w/o gen and w/ gen is this:
 				var operandType = instrNoGen.opcode.OperandType;


### PR DESCRIPTION
* Add workaround .NET Framework 3.5 reference assemblies (fixes x-platform dotnet build)
* Update to non-preview Microsoft.NETFramework.ReferenceAssemblies
* Update comment on why dotnet test doesn't work for .NET Framework 3.5
* Fix copy&paste error in MethodBodyReader unit test