### PR TITLE
Update travis build to use dotnet 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ mono:
 - latest
 - none
 
-# "dotnet: 3.0" works fine for linux, but osx needs the exact version for some reason.
-dotnet: 3.0.100
+# "dotnet: 3.1" works fine for linux, but osx needs the exact version for some reason.
+dotnet: 3.1.101
 
 before_install:
   - if [ "$TRAVIS_COMMIT_MESSAGE" == "Update documentation" ]; then echo "Skipping documentation only commit" && exit; fi

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -57,8 +57,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<!-- Reference assemblies are needed for non-Windows .NET Framework targeting builds. -->
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-		<PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" Condition="'$(TargetFramework)'=='net35'" />
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -35,8 +35,8 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="'$(TargetFramework)'!='netcoreapp2.0'">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<!--<PackageReference Include="NUnitTestAdapter" Version="2.2.0">
 			<PrivateAssets>all</PrivateAssets>
@@ -44,12 +44,10 @@
 		</PackageReference>-->
 	</ItemGroup>
 
-	<!--<ItemGroup>
+	<ItemGroup>
+		<!-- Reference assemblies are needed for non-Windows .NET Framework targeting builds. -->
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>-->
-
-	<ItemGroup Condition="'$(TargetFramework)'=='net35'">
-		<PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.0" PrivateAssets="All" Condition="'$(TargetFramework)'=='net35'" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,7 @@ before_build:
 
 for:
   -
-    # dotnet test currently doesn't work for .NET Framework 3.5, because Microsoft.NETFramework.ReferenceAssemblies
-    # doesn't have a build for it yet: https://github.com/dotnet/core-sdk/issues/2022
+    # dotnet test currently doesn't work for .NET Framework 3.5 - see comment in .travis.yml.
     matrix:
       only:
         - targetframework: net35


### PR DESCRIPTION
* Update travis build to use dotnet 3.1.
* Include reference assemblies again to fix non-Windows .NET Framework targeting builds.