### PR TITLE
Remove MonoMod.Common submodule, use Azure devbuild NuGet feed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "MonoMod.Common"]
-	path = MonoMod.Common
-	url = https://github.com/MonoMod/MonoMod.Common.git

--- a/Harmony.sln
+++ b/Harmony.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		azure-pipelines.yml = azure-pipelines.yml
+		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Harmony", "Harmony\Harmony.csproj", "{69AEE16A-B6E7-4642-8081-3928B32455DF}"

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -96,28 +96,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<!-- Import MonoMod.Common source and dependencies. -->
-		<Compile Include="..\MonoMod.Common\Shared\**\*.cs" />
-		<Compile Include="..\MonoMod.Common\Utils\**\*.cs" />
-		<Compile Include="..\MonoMod.Common\RuntimeDetour\**\*.cs" />
 		<!-- Cecil 0.11 drops support for .NET Framework 3.5 while introducing breaking API changes. -->
-		<PackageReference Include="Mono.Cecil" Version="0.10" Condition="'$(TargetFramework)'=='net35'">
-			<PrivateAssets Condition="!$(IsCoreOrStandard)">all</PrivateAssets>
+		<PackageReference Include="Mono.Cecil" Version="0.11.*" PrivateAssets="All">
+			<Version Condition="'$(TargetFramework)'=='net35'">0.10.*</Version>
 		</PackageReference>
-		<PackageReference Include="Mono.Cecil" Version="0.11" Condition="'$(TargetFramework)'!='net35'">
-			<PrivateAssets Condition="!$(IsCoreOrStandard)">all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.18" PrivateAssets="all" />
-	</ItemGroup>
-
-	<PropertyGroup>
-		<DefineConstants>MONOMOD_INTERNAL;$(DefineConstants)</DefineConstants>
-		<!-- .NET Core doesn't define NETSTANDARD, needed for MonoMod.Common. -->
-		<DefineConstants Condition="$(IsCoreOrStandard)">NETSTANDARD;$(DefineConstants)</DefineConstants>
-		<!-- Cecil 0.11 drops support for .NET Framework 3.5 while introducing breaking API changes. -->
-		<DefineConstants Condition="'$(TargetFramework)'=='net35'">CECIL0_10;$(DefineConstants)</DefineConstants>
-		<DefineConstants Condition="'$(TargetFramework)'!='net35'">CECIL0_11;$(DefineConstants)</DefineConstants>
-	</PropertyGroup>
+    <PackageReference Include="MonoMod.Common" Version="20.1.25.7" PrivateAssets="All" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.18" PrivateAssets="All" />
+  </ItemGroup>
 
 	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="!$(IsCoreOrStandard)">
 		<!--
@@ -128,30 +113,12 @@
 			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
 		</PropertyGroup>
 		<ItemGroup>
-			<InputAssemblies Include="Mono.Cecil.dll" />
-			<InputAssemblies Include="Mono.Cecil.Mdb.dll" />
-			<InputAssemblies Include="Mono.Cecil.Pdb.dll" />
-			<InputAssemblies Include="Mono.Cecil.Rocks.dll" />
+			<InputAssemblies Include="Mono.Cecil*.dll;MonoMod.Common*.dll" />
 			<InternalizeExcludeAssemblies Include="Harmony" />
 		</ItemGroup>
 
-		<ILRepack
-			OutputType="$(OutputType)"
-			MainAssembly="$(AssemblyName).dll"
-			OutputAssembly="$(AssemblyName).dll"
-			InputAssemblies="@(InputAssemblies)"
-			DebugInfo="true"
-			Internalize="true"
-			Parallel="true"
-			XmlDocumentation="true"
-			InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)"
-			KeyFile="..\keys\Harmony.Pair.snk"
-			WorkingDirectory="$(WorkingDirectory)" />
+		<ILRepack OutputType="$(OutputType)" MainAssembly="$(AssemblyName).dll" OutputAssembly="$(AssemblyName).dll" InputAssemblies="@(InputAssemblies)" DebugInfo="true" Internalize="true" Parallel="true" XmlDocumentation="true" InternalizeExcludeAssemblies="@(InternalizeExcludeAssemblies)" KeyFile="..\keys\Harmony.Pair.snk" WorkingDirectory="$(WorkingDirectory)" />
 
-	</Target>
-
-	<Target Name="DeleteCecil" AfterTargets="Build">
-		<Delete Files=".\**\Mono.Cecil.*" />
 	</Target>
 
 </Project>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net35;net45;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
@@ -63,10 +63,12 @@
 		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
 	</ItemGroup>
 
-  <ItemGroup>
-    <!-- Cecil 0.11 drops support for .NET Framework 3.5 while introducing breaking API changes. -->
-    <PackageReference Include="Mono.Cecil" Version="0.10" Condition="'$(TargetFramework)'=='net35'" PrivateAssets="all" />
-    <PackageReference Include="Mono.Cecil" Version="0.11" Condition="'$(TargetFramework)'!='net35'" PrivateAssets="all" />
-  </ItemGroup>
+	<ItemGroup>
+		<!-- Cecil 0.11 drops support for .NET Framework 3.5 while introducing breaking API changes. -->
+		<PackageReference Include="Mono.Cecil" Version="0.11.*" PrivateAssets="All">
+			<Version Condition="'$(TargetFramework)'=='net35'">0.10.*</Version>
+		</PackageReference>
+		<PackageReference Include="MonoMod.Common" Version="20.1.25.7" PrivateAssets="All" />
+	</ItemGroup>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="DevBuilds" value="https://pkgs.dev.azure.com/MonoMod/MonoMod/_packaging/DevBuilds/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This PR simply replaces the MonoMod.Common submodule with signed prebuilt MonoMod.Common NuGet packages from the [MonoMod Azure Artifacts devbuild feed](https://dev.azure.com/MonoMod/MonoMod/_packaging?_a=feed&feed=DevBuilds) and updates the existing ILRepack rules to include it.