### PR TITLE
Set DynamicMethodDefinition.OwnerType

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -96,7 +96,7 @@
 
 	<ItemGroup>
 		<!-- https://dev.azure.com/MonoMod/MonoMod/_packaging?_a=feed&feed=DevBuilds -->
-		<PackageReference Include="MonoMod.Common" Version="20.2.1.1" PrivateAssets="All" />
+		<PackageReference Include="MonoMod.Common" Version="20.2.2.1" PrivateAssets="All" />
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -236,7 +236,10 @@ namespace HarmonyLib
 				patchName,
 				returnType,
 				parameterTypes.ToArray()
-			);
+			)
+			{
+				OwnerType = original.DeclaringType
+			};
 
 #if NETSTANDARD2_0 || NETCOREAPP2_0
 #else

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -61,7 +61,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MonoMod.Common" Version="20.2.1.1" PrivateAssets="All" />
+		<PackageReference Include="MonoMod.Common" Version="20.2.2.1" PrivateAssets="All" />
 	</ItemGroup>
 
 	<Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">


### PR DESCRIPTION
This PR simply updates MonoMod.Common to 20.2.2.1 and sets the OwnerType of the DynamicMethodDefinition generated in MethodPatcher.cs, in an effort to fix the "calling assembly" issue reported by FailedShack on Discord.