### PR TITLE
Fix variable definition order: keep orig vars first

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -70,6 +70,7 @@ namespace HarmonyLib
 		{
 			try
 			{
+				var originalVariables = DeclareLocalVariables(source ?? original);
 				var privateVars = new Dictionary<string, LocalBuilder>();
 
 				LocalBuilder resultVariable = null;
@@ -110,7 +111,6 @@ namespace HarmonyLib
 				var skipOriginalLabel = il.DefineLabel();
 				var canHaveJump = AddPrefixes(privateVars, skipOriginalLabel);
 
-				var originalVariables = DeclareLocalVariables(source ?? original);
 				var copier = new MethodCopier(source ?? original, il, originalVariables);
 				foreach (var transpiler in transpilers)
 					copier.AddTranspiler(transpiler);


### PR DESCRIPTION
Commit f213218d30237cee09085ffe60cf6d0a94501b71 introduced a bug in which a method's original variables got defined after the temporary result variable and all other patch-related variables, resulting in (best case) the JITter throwing an `ExecutionEngineException` and (worst case) memory corruption in form of an uncatchable access violation.

This PR fixes the variable definition order.