### PR TITLE
Extract and test documentation examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 script:
   - dotnet build --framework ${netframework}
   - dotnet test HarmonyTests --framework ${netframework}
+  - Harmony/Documentation/examples/test-all.sh
 
 jobs:
   exclude:
@@ -67,7 +68,6 @@ jobs:
       script:
         - msbuild /p:Configuration=Release /p:TargetFrameworks=${netframework}
         - mono ./testrunner/NUnit.ConsoleRunner.*/tools/nunit3-console.exe HarmonyTests/bin/Release/${netframework}/HarmonyTests.dll --inprocess
-        - Harmony/Documentation/examples/test-all.sh
     - os: osx
       env: netframework=net35
       mono: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
       script:
         - msbuild /p:Configuration=Release /p:TargetFrameworks=${netframework}
         - mono ./testrunner/NUnit.ConsoleRunner.*/tools/nunit3-console.exe HarmonyTests/bin/Release/${netframework}/HarmonyTests.dll --inprocess
+        - Harmony/Documentation/examples/test-all.sh
     - os: osx
       env: netframework=net35
       mono: latest

--- a/Harmony/Documentation/articles/annotations.md
+++ b/Harmony/Documentation/articles/annotations.md
@@ -8,17 +8,7 @@ When you call harmony.**PatchAll()**, Harmony will search through all classes an
 
 A typical patch consists of a class with annotations that looks like this:
 
-```csharp
-[HarmonyPatch(typeof(SomeTypeHere))]
-[HarmonyPatch("SomeMethodName")]
-class MyPatches
-{
-	static void Postfix(...)
-	{
-		//...
-	}
-}
-```
+[!code-csharp[example](../examples/annotations_basic.cs?name=example)]
 
 This example annotates the class with enough information to identify the method to patch. Inside that class, you define a combination of **Prefix**, **Postfix**, **Finalizer** or **Transpiler** methods. Harmony will find them by their name and if you annotate those methods you can even have different names.
 
@@ -167,64 +157,10 @@ To patch methods with generic signatures, you need to patch specific versions of
 
 To simplify multiple patches while still using annotations, you can combine annotations with `TargetMethod()` and `TargetMethods()`:
 
-```csharp
-[HarmonyPatch] // make sure Harmony inspects the class
-class MyPatches()
-{
-	IEnumerable<MethodBase> TargetMethods()
-	{
-		return AccessTools.GetTypesFromAssembly(someAssembly)
-			.SelectMany(type => type.GetDeclaredMethods())
-			.Where(method => method.ReturnType != typeof(void) && method.Name.StartsWith("Player"))
-			.Cast<MethodBase>();
-	}
-
-	// prefix all methods in someAssembly with a non-void return type and beginning with "Player"
-	static void Prefix(MethodBase __originalMethod)
-	{
-		// use __originalMethod to decide what to do
-	}
-}
-```
+[!code-csharp[example](../examples/annotations_multiple.cs?name=example)]
 
 ### Combining annotations
 
 The combination of those annotations defines the target method. Annotations are **inherited** from class to method so you can use `[HarmonyPatch(Type)]` on the class and `[HarmonyPatch(String)]` on one of its methods to combine both.
 
-```csharp
-[HarmonyPatch(typeof(SomeType))]
-class MyPatches1
-{
-	[HarmonyPatch("SomeMethod1")]
-	static void Postfix() { }
-
-	[HarmonyPatch("SomeMethod2")]
-	static void Postfix() { }
-}
-
-[HarmonyPatch(typeof(TypeA))]
-class MyPatches2
-{
-	[HarmonyPatch("SomeMethod1")]
-	static void Prefix() { }
-
-	[HarmonyPatch("SomeMethod2")]
-	static void Prefix() { }
-
-	[HarmonyPatch(typeof(TypeB), "SomeMethod1")]
-	static void Postfix() { }
-}
-
-[HarmonyPatch]
-class MyPatches3
-{
-	[HarmonyPatch(typeof(TypeA), "SomeMethod1")]
-	static void Prefix() { }
-
-	[HarmonyPatch(typeof(TypeB), "SomeMethod2")]
-	static void Postfix() { }
-
-	[HarmonyPatch(typeof(TypeC), "SomeMethod3")]
-	static void Finalizer() { }
-}
-```
+[!code-csharp[example](../examples/annotations_combining.cs?name=example)]

--- a/Harmony/Documentation/articles/intro.md
+++ b/Harmony/Documentation/articles/intro.md
@@ -77,102 +77,14 @@ Where other patch libraries simply allow you to replace the original method, Har
 
 Original game code:
 
-```cs
-public class SomeGameClass
-{
-	private bool isRunning;
-	private int counter;
-
-	private int DoSomething()
-	{
-		if (isRunning)
-		{
-			counter++;
-			return counter * 10;
-		}
-	}
-}
-```
+[!code-csharp[example](../examples/intro_somegame.cs?name=example)]
 
 Patching with Harmony annotations:
 
-```cs
-// your code, most likely in your own dll
-
-using SomeGame;
-using HarmonyLib;
-
-public class MyPatcher
-{
-	// make sure DoPatching() is called at start either by
-	// the mod loader or by your injector
-
-	public static void DoPatching()
-	{
-		var harmony = new Harmony("com.example.patch");
-		harmony.PatchAll();
-	}
-}
-
-[HarmonyPatch(typeof(SomeGameClass))]
-[HarmonyPatch("DoSomething")]
-class Patch01
-{
-	static FieldRef<SomeGameClass,bool> isRunningRef =
-		AccessTools.FieldRefAccess<SomeGameClass, bool>("isRunning");
-
-	static bool Prefix(SomeGameClass __instance, ref int ___counter)
-	{
-		isRunningRef(__instance) = true;
-		if (___counter > 100)
-			return false;
-		___counter = 0;
-		return true;
-	}
-
-	static void Postfix(ref int __result)
-	{
-		__result *= 2;
-	}
-}
-```
+[!code-csharp[example](../examples/intro_annotations.cs?name=example)]
 
 Alternatively, manual patching with reflection:
 
-```cs
-// your code, most likely in your own dll
-
-using SomeGame;
-using HarmonyLib;
-
-public class MyPatcher
-{
-	// make sure DoPatching() is called at start either by
-	// the mod loader or by your injector
-
-	public static void DoPatching()
-	{
-		var harmony = new Harmony("com.example.patch");
-
-		//
-		var mOriginal = AccessTools.Method(typeof(SomeGameClass), "DoSomething");
-		var mPrefix = SymbolExtensions.GetMethodInfo(() => MyPrefix());
-		var mPostfix = SymbolExtensions.GetMethodInfo(() => MyPostfix());
-		// in general, add null checks here (new HarmonyMethod() does it for you too)
-
-		harmony.Patch(mOriginal, new HarmonyMethod(mPrefix), new HarmonyMethod(mPostfix));
-	}
-
-	public static void MyPrefix()
-	{
-		// ...
-	}
-
-	public static void MyPostfix()
-	{
-		// ...
-	}
-}
-```
+[!code-csharp[example](../examples/intro_manual.cs?name=example)]
 
 [note]: https://raw.githubusercontent.com/pardeike/Harmony/master/Harmony/Documentation/images/note.png

--- a/Harmony/Documentation/articles/patching-auxilary.md
+++ b/Harmony/Documentation/articles/patching-auxilary.md
@@ -48,14 +48,7 @@ static IEnumerable<MethodBase> CalculateMethods(Harmony instance)
 
 A typical implementation would `yield` the results like this:
 
-```csharp
-static IEnumerable<MethodBase> TargetMethods()
-{
-	yield return AccessTools.Method(typeof(Foo), "Method1");
-	yield return AccessTools.Method(typeof(Bar), "Method2");
-	// you could also iterate using reflections over many methods
-}
-```
+[!code-csharp[example](../examples/patching-auxilary.cs?name=yield)]
 
 ### Cleanup
 

--- a/Harmony/Documentation/articles/patching-finalizer.md
+++ b/Harmony/Documentation/articles/patching-finalizer.md
@@ -31,23 +31,6 @@ static void Finalizer(Exception __exception)
 
 ### Changing and rethrowing exceptions
 
-```csharp
-[Serializable]
-public class MyException : Exception
-{
-	public MyException() { }
-	public MyException(string message) : base(message) { }
-	public MyException(string message, Exception innerException) : base(message, innerException) { }
-	protected MyException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-	{
-		throw new NotImplementedException();
-	}
-}
-
-static Exception Finalizer(Exception __exception)
-{
-	return new MyException("Oops", __exception);
-}
-```
+[!code-csharp[example](../examples/patching-finalizer.cs?name=rethrow)]
 
 Beside their handling of exceptions they can receive the same arguments as Postfixes.

--- a/Harmony/Documentation/articles/patching-postfix.md
+++ b/Harmony/Documentation/articles/patching-postfix.md
@@ -13,25 +13,7 @@ A postfix is a method that is executed after the original method. It is commonly
 
 Since the postfix has access to the result of the original (or a prefix that has skipped the original), it can read or alter the result by using the argument `__result`. It must match the return type of the original or be assignable from it.
 
-```csharp
-public class OriginalCode
-{
-	public string GetName()
-	{
-		// ...
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "GetName")]
-class Patch
-{
-	static void Postfix(ref string __result)
-	{
-		if (__result == "foo")
-			__result = "bar";
-	}
-}
-```
+[!code-csharp[example](../examples/patching-postfix.cs?name=result)]
 
 ### Pass through postfixes
 
@@ -39,69 +21,13 @@ An alternative way to change the result of an original method is to use a **pass
 
 Harmony will call the postfix with the result of the original and will use the result of the postfix to continue. Since this works for all types, it is especially useful for types like `IEnumerable<T>` that cannot be combined with `ref`. This allows for changing the result with `yield` operations.
 
-```csharp
-public class OriginalCode
-{
-	public string GetName()
-	{
-		return "David";
-	}
-
-	public IEnumerable<int> GetNumbers()
-	{
-		yield return 1;
-		yield return 2;
-		yield return 3;
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "GetName")]
-class Patch1
-{
-	static string Postfix(string name)
-	{
-		return "Hello " + name;
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "GetNumbers")]
-class Patch2
-{
-	static IEnumerable<int> Postfix(IEnumerable<int> values)
-	{
-		yield return 0;
-		foreach (var value in values)
-			if (value > 1)
-				yield return value * 10;
-		yield return 99;
-	}
-}
-
-// will make GetNumbers() return [0, 20, 30, 99] instead of [1, 2, 3]
-```
+[!code-csharp[example](../examples/patching-postfix.cs?name=passthrough)]
 
 ### Reading original arguments
 
 There are many ways to access original arguments and even private fields: by name convention and by attributes. You can read more about that in the [Injections](patching-injections.md) chapter. Here is a simple example:
 
-```csharp
-public class OriginalCode
-{
-	public void Test(int counter)
-	{
-		// ...
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "Test")]
-class Patch
-{
-	static void Prefix(int counter)
-	{
-		FileLog.Log("counter = " + counter);
-	}
-}
-```
+[!code-csharp[example](../examples/patching-postfix.cs?name=args)]
 
 ### Postfixes always run
 

--- a/Harmony/Documentation/articles/patching-prefix.md
+++ b/Harmony/Documentation/articles/patching-prefix.md
@@ -13,25 +13,7 @@ A prefix is a method that is executed before the original method. It is commonly
 
 ### Reading and changing arguments
 
-```csharp
-public class OriginalCode
-{
-	public void Test(int counter, string name)
-	{
-		// ...
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "Test")]
-class Patch
-{
-	static void Prefix(int counter, ref string name)
-	{
-		FileLog.Log("counter = " + counter); // read
-		name = "test"; // write with ref keyword
-	}
-}
-```
+[!code-csharp[example](../examples/patching-prefix.cs?name=args)]
 
 ### Changing the result and skipping the original
 
@@ -41,51 +23,11 @@ To skip the original, let the prefix return a `bool` and return `true` to let th
 
 ![note] It is not recommended to skip the original unless you want to completely change the way it works. If you only want a small change or a side effect, using a postfix or a transpiler is always preferred since it allows for multiple users changing the original without each implementation fighting over how the original should behave.
 
-```csharp
-public class OriginalCode
-{
-	public string GetName()
-	{
-		// ...
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "GetName")]
-class Patch
-{
-	static bool Prefix(ref string __result)
-	{
-		__result = "test";
-		return true; // make sure you only skip if really necessary
-	}
-}
-```
+[!code-csharp[example](../examples/patching-prefix.cs?name=skip)]
 
 Here is another example showing the diference between what the original method returns and what the Prefix returns. it illustrate that the boolean return value of the Prefix only determines if the original gets executed or not.
 
-```csharp
-public class OriginalCode
-{
-	public bool IsFullAfterTakingIn(int i)
-	{
-		// do expensive calculations
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "IsFullAfterTakingIn")]
-class Patch
-{
-	static bool Prefix(ref bool __result, int i)
-	{
-		if (i > 5)
-		{
-			__result = true; // any call to IsFullAfterTakingIn(i) where i > 5 now immediately returns true
-			return false; // skips the original and its expensive calculations
-		}
-		return true; // make sure you only skip if really necessary
-	}
-}
-```
+[!code-csharp[example](../examples/patching-prefix.cs?name=skip_maybe)]
 
 ### Passing state between prefix and postfix
 
@@ -93,33 +35,6 @@ If you want to share state between your prefix and the corresponding postfix, yo
 
 ![note] This only works if Prefix and Postfix are defined in the same class since Harmony internally uses the declaring type as a key to store the information.
 
-```cs
-public class OriginalCode
-{
-	public void Test(int counter, string name)
-	{
-		// ...
-	}
-}
-
-[HarmonyPatch(typeof(OriginalCode), "Test")]
-class Patch
-{
-	// this example uses a Stopwatch type to measure
-	// and share state between prefix and postfix
-
-	static void Prefix(out Stopwatch __state)
-	{
-		__state = new Stopwatch(); // assign your own state
-		__state.Start();
-	}
-
-	static void Postfix(Stopwatch __state)
-	{
-		__state.Stop();
-		FileLog.Log(__state.Elapsed);
-	}
-}
-```
+[!code-csharp[example](../examples/patching-prefix.cs?name=state)]
 
 [note]: https://raw.githubusercontent.com/pardeike/Harmony/master/Harmony/Documentation/images/note.png

--- a/Harmony/Documentation/articles/priorities.md
+++ b/Harmony/Documentation/articles/priorities.md
@@ -15,67 +15,19 @@ Example:
 
 Given the following method:
 
-```csharp
-class Foo
-{
-	static string Bar()
-	{
-		return "secret";
-	}
-}
-```
+[!code-csharp[example](../examples/priorities.cs?name=foo)]
 
 and **Plugin 1**
 
-```csharp
-var harmony = new Harmony("net.example.plugin1");
-harmony.PatchAll(Assembly.GetExecutingAssembly());
-
-[HarmonyPatch(typeof(Foo))]
-[HarmonyPatch("Bar")]
-class MyPatch
-{
-	static void Postfix(ref result)
-	{
-		result = "new secret 1";
-	}
-}
-```
+[!code-csharp[example](../examples/priorities.cs?name=plugin1)]
 
 and **Plugin 2**
 
-```csharp
-var harmony = new Harmony("net.example.plugin2");
-harmony.PatchAll(Assembly.GetExecutingAssembly());
-
-[HarmonyPatch(typeof(Foo))]
-[HarmonyPatch("Bar")]
-class MyPatch
-{
-	static void Postfix(ref result)
-	{
-		result = "new secret 2";
-	}
-}
-```
+[!code-csharp[example](../examples/priorities.cs?name=plugin2)]
 
 a call to `Foo.Bar()` would return "new secret 2" because both plugins register their Postfix with the same priority and so the second Postfix overrides the result of the first one. As an author of Plugin 1, you could rewrite your code to
 
-```csharp
-var harmony = new Harmony("net.example.plugin1");
-harmony.PatchAll(Assembly.GetExecutingAssembly());
-
-[HarmonyPatch(typeof(Foo))]
-[HarmonyPatch("Bar")]
-class MyPatch
-{
-	[HarmonyAfter(new string[] { "net.example.plugin2" })]
-	static void Postfix(ref result)
-	{
-		result = "new secret 1";
-	}
-}
-```
+[!code-csharp[example](../examples/priorities.cs?name=plugin1b)]
 
 and would be executed after net.example.plugin2 which gives you (for a Postfix) the chance to change the result last. Alternatively, you could annotate with [HarmonyPriority(Priority.Low)] to come after plugin1.
 

--- a/Harmony/Documentation/articles/utilities.md
+++ b/Harmony/Documentation/articles/utilities.md
@@ -53,46 +53,7 @@ public static void IterateProperties(object source, object target, Action<Traver
 
 Example:
 
-```csharp
-class Foo
-{
-	struct Bar
-	{
-		static string secret = "hello";
-
-		public string ModifiedSecret()
-		{
-			return secret.ToUpper();
-		}
-	}
-
-	Bar myBar
-	{
-		get
-		{
-			return new Bar();
-		}
-	}
-
-	public string GetSecret()
-	{
-		return myBar.ModifiedSecret();
-	}
-
-	Foo()
-	{
-	}
-
-	static Foo MakeFoo()
-	{
-		return new Foo();
-	}
-}
-
-var foo = Traverse.Create<Foo>().Method("MakeFoo").GetValue<Foo>();
-Traverse.Create(foo).Property("myBar").Field("secret").SetValue("world");
-Console.WriteLine(foo.GetSecret()); // outputs WORLD
-```
+[!code-csharp[example](../examples/utilities.cs?name=example)]
 
 Although most fields, properties and methods in that class hierarchy are private, Traverse can easily access anything. It has build-in null protection and propagates null as a result if any of the intermediates would encounter null. It works with static types and caches lookups which makes it pretty fast.
 

--- a/Harmony/Documentation/examples/annotations_basic.cs
+++ b/Harmony/Documentation/examples/annotations_basic.cs
@@ -1,0 +1,15 @@
+// <example>
+using HarmonyLib;
+
+[HarmonyPatch(typeof(SomeTypeHere))]
+[HarmonyPatch("SomeMethodName")]
+class MyPatches
+{
+	static void Postfix(/*...*/)
+	{
+		//...
+	}
+}
+// </example>
+
+class SomeTypeHere {}

--- a/Harmony/Documentation/examples/annotations_combining.cs
+++ b/Harmony/Documentation/examples/annotations_combining.cs
@@ -1,0 +1,48 @@
+// <example>
+using HarmonyLib;
+
+[HarmonyPatch(typeof(SomeType))]
+class MyPatches1
+{
+	[HarmonyPostfix]
+	[HarmonyPatch("SomeMethod1")]
+	static void Postfix1() { }
+
+	[HarmonyPostfix]
+	[HarmonyPatch("SomeMethod2")]
+	static void Postfix2() { }
+}
+
+[HarmonyPatch(typeof(TypeA))]
+class MyPatches2
+{
+	[HarmonyPrefix]
+	[HarmonyPatch("SomeMethod1")]
+	static void Prefix1() { }
+
+	[HarmonyPrefix]
+	[HarmonyPatch("SomeMethod2")]
+	static void Prefix2() { }
+
+	[HarmonyPatch(typeof(TypeB), "SomeMethod1")]
+	static void Postfix() { }
+}
+
+[HarmonyPatch]
+class MyPatches3
+{
+	[HarmonyPatch(typeof(TypeA), "SomeMethod1")]
+	static void Prefix() { }
+
+	[HarmonyPatch(typeof(TypeB), "SomeMethod2")]
+	static void Postfix() { }
+
+	[HarmonyPatch(typeof(TypeC), "SomeMethod3")]
+	static void Finalizer() { }
+}
+// </example>
+
+class SomeType {}
+class TypeA {}
+class TypeB {}
+class TypeC {}

--- a/Harmony/Documentation/examples/annotations_multiple.cs
+++ b/Harmony/Documentation/examples/annotations_multiple.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+
+public class Example
+{
+	// <example>
+	[HarmonyPatch] // make sure Harmony inspects the class
+	class MyPatches
+	{
+		IEnumerable<MethodBase> TargetMethods()
+		{
+			return AccessTools.GetTypesFromAssembly(someAssembly)
+				.SelectMany(type => type.GetMethods())
+				.Where(method => method.ReturnType != typeof(void) && method.Name.StartsWith("Player"))
+				.Cast<MethodBase>();
+		}
+
+		// prefix all methods in someAssembly with a non-void return type and beginning with "Player"
+		static void Prefix(MethodBase __originalMethod)
+		{
+			// use __originalMethod to decide what to do
+		}
+	}
+	// </example>
+
+	class MyCode {}
+	public static Assembly someAssembly;
+}

--- a/Harmony/Documentation/examples/basics.cs
+++ b/Harmony/Documentation/examples/basics.cs
@@ -1,0 +1,147 @@
+// <import>
+using HarmonyLib;
+// </import>
+
+using System.Reflection;
+
+public class Example
+{
+	static void Main()
+	{
+		// <create>
+		var harmony = new Harmony("com.company.project.product");
+		// </create>
+
+		// <debug>
+		Harmony.DEBUG = true;
+		// </debug>
+
+		// <log>
+		FileLog.Log("something");
+		// or buffered:
+		FileLog.LogBuffered("A");
+		FileLog.LogBuffered("B");
+		FileLog.FlushBuffer(); // don't forget to flush
+		// </log>
+
+		// <patch_annotation>
+		var assembly = Assembly.GetExecutingAssembly();
+		harmony.PatchAll(assembly);
+
+		// or implying current assembly:
+		harmony.PatchAll();
+		// </patch_annotation>
+
+		void PatchManual()
+		{
+			// <patch_manual>
+			// add null checks to the following lines, they are omitted for clarity
+			var original = typeof(TheClass).GetMethod("TheMethod");
+			var prefix = typeof(MyPatchClass1).GetMethod("SomeMethod");
+			var postfix = typeof(MyPatchClass2).GetMethod("SomeMethod");
+
+			harmony.Patch(original, new HarmonyMethod(prefix), new HarmonyMethod(postfix));
+
+			// You can use named arguments to specify certain patch types only:
+			harmony.Patch(original, postfix: new HarmonyMethod(postfix));
+			harmony.Patch(original, prefix: new HarmonyMethod(prefix), transpiler: new HarmonyMethod(transpiler));
+			// </patch_manual>
+
+			// <patch_method>
+			var harmonyPostfix = new HarmonyMethod(postfix)
+			{
+				priority = Priority.Low,
+				before = new[] { "that.other.harmony.user" }
+			};
+			// </patch_method>
+		}
+		PatchManual();
+		
+		// <patch_getall>
+		var originalMethods = Harmony.GetAllPatchedMethods();
+		foreach (var method in originalMethods) { }
+		// </patch_getall>
+
+		// <patch_get>
+		var myOriginalMethods = harmony.GetPatchedMethods();
+		foreach (var method in myOriginalMethods) { }
+		// </patch_get>
+
+		void PatchInfo()
+		{
+			// <patch_info>
+			// get the MethodBase of the original
+			var original = typeof(TheClass).GetMethod("TheMethod");
+
+			// retrieve all patches
+			var patches = Harmony.GetPatchInfo(original);
+			if (patches == null) return; // not patched
+
+			// get a summary of all different Harmony ids involved
+			FileLog.Log("all owners: " + patches.Owners);
+
+			// get info about all Prefixes/Postfixes/Transpilers
+			foreach (var patch in patches.Prefixes)
+			{
+				FileLog.Log("index: " + patch.index);
+				FileLog.Log("owner: " + patch.owner);
+				FileLog.Log("patch method: " + patch.PatchMethod);
+				FileLog.Log("priority: " + patch.priority);
+				FileLog.Log("before: " + patch.before);
+				FileLog.Log("after: " + patch.after);
+			}
+			// </patch_info>
+		}
+		PatchInfo();
+
+		// <patch_has>
+		if(Harmony.HasAnyPatches("their.harmony.id")) { }
+		// </patch_has>
+
+		// <version>
+		var dict = Harmony.VersionInfo(out var myVersion);
+		FileLog.Log("My version: " + myVersion);
+		foreach (var entry in dict)
+		{
+			var id = entry.Key;
+			var version = entry.Value;
+			FileLog.Log("Mod " + id + " uses Harmony version " + version);
+		}
+		// </version>
+	}
+
+	void Unpatch()
+	{
+		// <unpatch>
+		// every patch on every method ever patched (including others patches):
+		var harmony = new Harmony("my.harmony.id");
+		harmony.UnpatchAll();
+
+		// only the patches that one specific Harmony instance did:
+		harmony.UnpatchAll("their.harmony.id");
+		// </unpatch>
+
+		// <unpatch_one>
+		var original = typeof(TheClass).GetMethod("TheMethod");
+
+		// all prefixes on the original method:
+		harmony.Unpatch(original, HarmonyPatchType.Prefix);
+
+		// all prefixes from that other Harmony user on the original method:
+		harmony.Unpatch(original, HarmonyPatchType.Prefix, "their.harmony.id");
+
+		// all patches from that other Harmony user:
+		harmony.Unpatch(original, HarmonyPatchType.All, "their.harmony.id");
+
+		// removing a specific patch:
+		var patch = typeof(TheClass).GetMethod("SomePrefix");
+		harmony.Unpatch(original, patch);
+		// </unpatch_one>
+	}
+
+	class TheClass {}
+	class MyPatchClass1 {}
+	class MyPatchClass2 {}
+
+	public static MethodInfo transpiler;
+}

--- a/Harmony/Documentation/examples/execution_with.cs
+++ b/Harmony/Documentation/examples/execution_with.cs
@@ -1,0 +1,78 @@
+using System;
+
+public class Code
+{
+	// <example>
+	static R ReplacementMethod(T optionalThisArgument /*, ... arguments ... */ )
+	{
+		R result = default;
+		bool finalized = false;
+		Exception ex = null;
+
+		// All this code is generated dynamically, which means that
+		// Harmony can build it depending on
+		//
+		// - if there are any finalizers (otherwise, skip try-catch)
+		//
+		// - re-throwing can be dynamic too depending on if at least
+		//   one finalizer returns a non-void result
+
+		try
+		{
+			result = Original(/* ... arguments ... */);
+
+			// finalizers get all the arguments a prefix could get too
+			// plus one new one: "Exception __exception"
+			// they SHOULD NOT edit the passed exception but instead
+			// signal to Harmony that they change it by returning it
+
+			// here finalizers are called without try-catch so they are
+			// allowed to throw exceptions. note, that it is perfectly
+			// fine to get null passed into the exception argument
+
+			SimpleFinalizer(ref result);
+			ex = EditFinalizer(ex, ref result);
+			finalized = true;
+
+			if (ex != null) throw ex;
+			return result;
+		}
+		catch(Exception e)
+		{
+			ex = e;
+
+			// finalizers will get another chance here, so they are
+			// guaranteed to run even if their first invocation threw
+			// an exception
+
+			if (!finalized)
+			{
+				try { SimpleFinalizer(ref result); } catch { }
+				try { ex = EditFinalizer(ex, ref result); } catch { }
+			}
+
+			if (allVoid)
+			{
+				// alternative 1: all finalizers are returning void
+				throw;
+			}
+			else
+			{
+				 // alternative 2: at least one non-void finalizer
+				if (ex != null) throw ex;
+			}
+
+			return result;
+		}
+	}
+
+	// given the following signatures:
+	public static R Original() { return new R("original"); }
+	public static void SimpleFinalizer(ref R result) { }
+	public static Exception EditFinalizer(Exception ex, ref R result) { return ex; }
+	// </example>
+
+	public class R { public R(string s) {} }
+	public class T {}
+	public static bool allVoid;
+}

--- a/Harmony/Documentation/examples/execution_without.cs
+++ b/Harmony/Documentation/examples/execution_without.cs
@@ -1,0 +1,56 @@
+class Code
+{
+	// <example>
+
+	// while patching, the method ModifiedOriginal is created by chaining
+	// all transpilers. This happens only once when you patch, not during runtime
+	//
+	// var codes = GetCodeFromOriginal(originalMethod);
+	// codes = Transpiler1(codes);
+	// codes = Transpiler2(codes);
+	// codes = Transpiler3(codes);
+	// static ModifiedOriginal = GenerateDynamicMethod(codes);
+
+	static R ReplacementMethod(T optionalThisArgument, params object[] arguments)
+	{
+		R result = default;
+		bool run = true;
+
+		// Harmony separates all Prefix patches into those that change the
+		// original methods result/execution and those who have no side efects
+		// Lets call all prefixes with no side effect "SimplePrefix" and add
+		// a number to them that indicates their sort order after applying
+		// priorities to them:
+
+		SimplePrefix1(arguments);
+		if (run) run = Prefix2();
+		SimplePrefix3(arguments);
+		SimplePrefix4(arguments);
+		if (run) Prefix5(ref someArgument, ref result);
+		// ...
+
+		if (run) result = ModifiedOriginal(arguments);
+
+		Postfix1(ref result);
+		result = Postfix2(result, arguments);
+		Postfix3();
+		// ...
+
+		return result;
+	}
+	// </example>
+
+	class T {}
+	class R {}
+	static int someArgument;
+
+	static void SimplePrefix1(params object[] arguments) {}
+	static bool Prefix2() { return true; }
+	static void SimplePrefix3(params object[] arguments) {}
+	static void SimplePrefix4(params object[] arguments) {}
+	static bool Prefix5(ref int i, ref R r) { return true; }
+	static R ModifiedOriginal(params object[] arguments) { return null; }
+	static void Postfix1(ref R r) {}
+	static R Postfix2(R r, params object[] arguments) { return r; }
+	static void Postfix3() {}
+}

--- a/Harmony/Documentation/examples/intro_annotations.cs
+++ b/Harmony/Documentation/examples/intro_annotations.cs
@@ -1,0 +1,43 @@
+// extra-arg: intro_somegame.cs
+using System.Reflection;
+
+// <example>
+// your code, most likely in your own dll
+
+using SomeGame;
+using HarmonyLib;
+
+public class MyPatcher
+{
+	// make sure DoPatching() is called at start either by
+	// the mod loader or by your injector
+
+	public static void DoPatching()
+	{
+		var harmony = new Harmony("com.example.patch");
+		harmony.PatchAll();
+	}
+}
+
+[HarmonyPatch(typeof(SomeGameClass))]
+[HarmonyPatch("DoSomething")]
+class Patch01
+{
+	static AccessTools.FieldRef<SomeGameClass,bool> isRunningRef =
+		AccessTools.FieldRefAccess<SomeGameClass, bool>("isRunning");
+
+	static bool Prefix(SomeGameClass __instance, ref int ___counter)
+	{
+		isRunningRef(__instance) = true;
+		if (___counter > 100)
+			return false;
+		___counter = 0;
+		return true;
+	}
+
+	static void Postfix(ref int __result)
+	{
+		__result *= 2;
+	}
+}
+// </example>

--- a/Harmony/Documentation/examples/intro_annotations.cs
+++ b/Harmony/Documentation/examples/intro_annotations.cs
@@ -1,4 +1,4 @@
-// extra-arg: intro_somegame.cs
+// extra-file: intro_somegame.cs
 using System.Reflection;
 
 // <example>

--- a/Harmony/Documentation/examples/intro_manual.cs
+++ b/Harmony/Documentation/examples/intro_manual.cs
@@ -1,0 +1,38 @@
+// extra-arg: intro_somegame.cs
+using System.Reflection;
+
+// <example>
+// your code, most likely in your own dll
+
+using SomeGame;
+using HarmonyLib;
+
+public class MyPatcher
+{
+	// make sure DoPatching() is called at start either by
+	// the mod loader or by your injector
+
+	public static void DoPatching()
+	{
+		var harmony = new Harmony("com.example.patch");
+
+		//
+		var mOriginal = AccessTools.Method(typeof(SomeGameClass), "DoSomething");
+		var mPrefix = SymbolExtensions.GetMethodInfo(() => MyPrefix());
+		var mPostfix = SymbolExtensions.GetMethodInfo(() => MyPostfix());
+		// in general, add null checks here (new HarmonyMethod() does it for you too)
+
+		harmony.Patch(mOriginal, new HarmonyMethod(mPrefix), new HarmonyMethod(mPostfix));
+	}
+
+	public static void MyPrefix()
+	{
+		// ...
+	}
+
+	public static void MyPostfix()
+	{
+		// ...
+	}
+}
+// </example>

--- a/Harmony/Documentation/examples/intro_manual.cs
+++ b/Harmony/Documentation/examples/intro_manual.cs
@@ -1,4 +1,4 @@
-// extra-arg: intro_somegame.cs
+// extra-file: intro_somegame.cs
 using System.Reflection;
 
 // <example>

--- a/Harmony/Documentation/examples/intro_somegame.cs
+++ b/Harmony/Documentation/examples/intro_somegame.cs
@@ -1,0 +1,21 @@
+namespace SomeGame
+{
+	#pragma warning disable CS0649 // Field 'SomeGameClass.isRunning' is never assigned to, and will always have its default value false
+
+	// <example>
+	public class SomeGameClass
+	{
+		private bool isRunning;
+		private int counter;
+
+		private int DoSomething()
+		{
+			if (isRunning)
+			{
+				counter++;
+			}
+			return counter * 10;
+		}
+	}
+	// </example>
+}

--- a/Harmony/Documentation/examples/patching-auxilary.cs
+++ b/Harmony/Documentation/examples/patching-auxilary.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+
+class Foo {}
+class Bar {}
+
+class Example
+{	
+	// <yield>
+	static IEnumerable<MethodBase> TargetMethods()
+	{
+		yield return AccessTools.Method(typeof(Foo), "Method1");
+		yield return AccessTools.Method(typeof(Bar), "Method2");
+		// you could also iterate using reflections over many methods
+	}
+	// </yield>
+}

--- a/Harmony/Documentation/examples/patching-finalizer.cs
+++ b/Harmony/Documentation/examples/patching-finalizer.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using HarmonyLib;
+
+class Foo {}
+class Bar {}
+
+class Example
+{	
+	// <rethrow>
+	[Serializable]
+	public class MyException : Exception
+	{
+		public MyException() { }
+		public MyException(string message) : base(message) { }
+		public MyException(string message, Exception innerException) : base(message, innerException) { }
+		protected MyException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	static Exception Finalizer(Exception __exception)
+	{
+		return new MyException("Oops", __exception);
+	}
+	// </rethrow>
+}

--- a/Harmony/Documentation/examples/patching-postfix.cs
+++ b/Harmony/Documentation/examples/patching-postfix.cs
@@ -1,0 +1,93 @@
+using HarmonyLib;
+using System.Collections.Generic;
+
+public class ResultExample
+{
+	// <result>
+	public class OriginalCode
+	{
+		public string GetName()
+		{
+			return name; // ...
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "GetName")]
+	class Patch
+	{
+		static void Postfix(ref string __result)
+		{
+			if (__result == "foo")
+				__result = "bar";
+		}
+	}
+	// </result>
+
+	public static string name;
+}
+
+public class PassThroughExample
+{
+	// <passthrough>
+	public class OriginalCode
+	{
+		public string GetName()
+		{
+			return "David";
+		}
+
+		public IEnumerable<int> GetNumbers()
+		{
+			yield return 1;
+			yield return 2;
+			yield return 3;
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "GetName")]
+	class Patch1
+	{
+		static string Postfix(string name)
+		{
+			return "Hello " + name;
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "GetNumbers")]
+	class Patch2
+	{
+		static IEnumerable<int> Postfix(IEnumerable<int> values)
+		{
+			yield return 0;
+			foreach (var value in values)
+				if (value > 1)
+					yield return value * 10;
+			yield return 99;
+		}
+	}
+
+	// will make GetNumbers() return [0, 20, 30, 99] instead of [1, 2, 3]
+	// </passthrough>
+}
+
+public class ArgsExample
+{
+	// <args>
+	public class OriginalCode
+	{
+		public void Test(int counter)
+		{
+			// ...
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "Test")]
+	class Patch
+	{
+		static void Prefix(int counter)
+		{
+			FileLog.Log("counter = " + counter);
+		}
+	}
+	// </args>
+}

--- a/Harmony/Documentation/examples/patching-prefix.cs
+++ b/Harmony/Documentation/examples/patching-prefix.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using System.Collections.Generic;
+using HarmonyLib;
+
+public class ArgsExample
+{
+	// <args>
+	public class OriginalCode
+	{
+		public void Test(int counter, string name)
+		{
+			// ...
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "Test")]
+	class Patch
+	{
+		static void Prefix(int counter, ref string name)
+		{
+			FileLog.Log("counter = " + counter); // read
+			name = "test"; // write with ref keyword
+		}
+	}
+	// </args>
+}
+
+public class SkipExample
+{
+	// <skip>
+	public class OriginalCode
+	{
+		public string GetName()
+		{
+			return name; // ...
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "GetName")]
+	class Patch
+	{
+		static bool Prefix(ref string __result)
+		{
+			__result = "test";
+			return true; // make sure you only skip if really necessary
+		}
+	}
+	// </skip>
+
+	public static string name;
+}
+
+public class SkipMaybeExample
+{
+	// <skip_maybe>
+	public class OriginalCode
+	{
+		public bool IsFullAfterTakingIn(int i)
+		{
+			return DoSomeExpensiveCalculation() > i;
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "IsFullAfterTakingIn")]
+	class Patch
+	{
+		static bool Prefix(ref bool __result, int i)
+		{
+			if (i > 5)
+			{
+				__result = true; // any call to IsFullAfterTakingIn(i) where i > 5 now immediately returns true
+				return false; // skips the original and its expensive calculations
+			}
+			return true; // make sure you only skip if really necessary
+		}
+	}
+	// </skip_maybe>
+
+	static int DoSomeExpensiveCalculation() { return 0; }
+}
+
+public class StateExample
+{
+	// <state>
+	public class OriginalCode
+	{
+		public void Test(int counter, string name)
+		{
+			// ...
+		}
+	}
+
+	[HarmonyPatch(typeof(OriginalCode), "Test")]
+	class Patch
+	{
+		// this example uses a Stopwatch type to measure
+		// and share state between prefix and postfix
+
+		static void Prefix(out Stopwatch __state)
+		{
+			__state = new Stopwatch(); // assign your own state
+			__state.Start();
+		}
+
+		static void Postfix(Stopwatch __state)
+		{
+			__state.Stop();
+			FileLog.Log(__state.Elapsed.ToString());
+		}
+	}
+	// </state>
+}

--- a/Harmony/Documentation/examples/patching-transpiler.cs
+++ b/Harmony/Documentation/examples/patching-transpiler.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+class TypicalExample
+{
+	#pragma warning disable CS0252 // Possible unintended reference comparison; to get a value comparison, cast the left hand side to type 'FieldInfo'
+	
+	// <typical>
+	static FieldInfo f_someField = AccessTools.Field(typeof(SomeType), "someField");
+	static MethodInfo m_MyExtraMethod = SymbolExtensions.GetMethodInfo(() => Tools.MyExtraMethod());
+
+	// looks for STDFLD someField and inserts CALL MyExtraMethod before it
+	static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+	{
+		var found = false;
+		foreach (var instruction in instructions)
+		{
+			if (instruction.opcode == OpCodes.Stfld && instruction.operand == f_someField)
+			{
+				yield return new CodeInstruction(OpCodes.Call, m_MyExtraMethod);
+				found = true;
+			}
+			yield return instruction;
+		}
+		if (found == false)
+			ReportError("Cannot find <Stdfld someField> in OriginalType.OriginalMethod");
+	}
+	// </typical>
+
+	class SomeType {}
+
+	class Tools
+	{
+		public static MethodInfo MyExtraMethod() { return null; }
+	}
+
+	static void ReportError(string s) {}
+}
+
+class CaravanExample
+{
+	// <caravan>
+	[HarmonyPatch(typeof(Dialog_FormCaravan))]
+	[HarmonyPatch("CheckForErrors")]
+	public static class Dialog_FormCaravan_CheckForErrors_Patch
+	{
+		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+		{
+			var foundMassUsageMethod = false;
+			int startIndex = -1, endIndex = -1;
+
+			var codes = new List<CodeInstruction>(instructions);
+			for (int i = 0; i < codes.Count; i++)
+			{
+				if (codes[i].opcode == OpCodes.Ret)
+				{
+					if (foundMassUsageMethod)
+					{
+						Log.Error("END " + i);
+
+						endIndex = i; // include current 'ret'
+						break;
+					}
+					else
+					{
+						Log.Error("START " + (i + 1));
+
+						startIndex = i + 1; // exclude current 'ret'
+
+						for (int j = startIndex; j < codes.Count; j++)
+						{
+							if (codes[j].opcode == OpCodes.Ret)
+								break;
+							var strOperand = codes[j].operand as String;
+							if (strOperand == "TooBigCaravanMassUsage")
+							{
+								foundMassUsageMethod = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (startIndex > -1 && endIndex > -1)
+			{
+				// we cannot remove the first code of our range since some jump actually jumps to
+				// it, so we replace it with a no-op instead of fixing that jump (easier).
+				codes[startIndex].opcode = OpCodes.Nop;
+				codes.RemoveRange(startIndex + 1, endIndex - startIndex - 1);
+			}
+
+			return codes.AsEnumerable();
+		}
+	}
+	// </caravan>
+
+	class Dialog_FormCaravan {}
+
+	class Log
+	{
+		public static void Error(string s) {}
+	}
+}

--- a/Harmony/Documentation/examples/priorities.cs
+++ b/Harmony/Documentation/examples/priorities.cs
@@ -1,0 +1,76 @@
+using HarmonyLib;
+using System.Reflection;
+
+// <foo>
+class Foo
+{
+	static string Bar()
+	{
+		return "secret";
+	}
+}
+// </foo>
+
+class Plugin1
+{
+	// <plugin1>
+	void Main()
+	{
+		var harmony = new Harmony("net.example.plugin1");
+		harmony.PatchAll(Assembly.GetExecutingAssembly());
+	}
+
+	[HarmonyPatch(typeof(Foo))]
+	[HarmonyPatch("Bar")]
+	class MyPatch
+	{
+		static void Postfix(ref string result)
+		{
+			result = "new secret 1";
+		}
+	}
+	// </plugin1>
+}
+
+class Plugin1b
+{
+	// <plugin1b>
+	void Main()
+	{
+		var harmony = new Harmony("net.example.plugin1");
+		harmony.PatchAll(Assembly.GetExecutingAssembly());
+	}
+
+	[HarmonyPatch(typeof(Foo))]
+	[HarmonyPatch("Bar")]
+	class MyPatch
+	{
+		[HarmonyAfter(new string[] { "net.example.plugin2" })]
+		static void Postfix(ref string result)
+		{
+			result = "new secret 1";
+		}
+	}
+	// </plugin1b>
+}
+
+class Plugin2
+{
+	// <plugin2>
+	void Main()
+	{
+		var harmony = new Harmony("net.example.plugin2");
+		harmony.PatchAll(Assembly.GetExecutingAssembly());
+	}
+
+	[HarmonyPatch(typeof(Foo))]
+	[HarmonyPatch("Bar")]
+	class MyPatch
+	{
+		static void Postfix(ref string result)
+		{
+			result = "new secret 2";
+		}
+	}
+	// </plugin2>
+}

--- a/Harmony/Documentation/examples/reverse-patching.cs
+++ b/Harmony/Documentation/examples/reverse-patching.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Collections.Generic;
+using HarmonyLib;
+
+public class Example
+{
+	// <example>
+	private class OriginalCode
+	{
+		private void Test(int counter, string name)
+		{
+			// ...
+		}
+	}
+
+	[HarmonyPatch]
+	public class Patch
+	{
+		[HarmonyReversePatch]
+		[HarmonyPatch(typeof(OriginalCode), "Test")]
+		public static void MyTest(object instance, int counter, string name)
+		{
+			// its a stub so it has no initial content
+			throw new NotImplementedException("It's a stub");
+		}
+	}
+
+	class Main
+	{
+		void Test()
+		{
+			// here we call OriginalCode.Test()
+			Patch.MyTest(originalInstance, 100, "hello");
+		}
+	}
+	// </example>
+
+	public static object originalInstance;
+}
+
+class TranspilerExample
+{
+	// <transpiler>
+	private class OriginalClass
+	{
+		private string SpecialCalculation(string original, int n)
+		{
+			var parts = original.Split('-').Reverse().ToArray();
+			var str = string.Join("", parts) + n;
+			return str + "Prolog";
+		}
+	}
+
+	[HarmonyPatch]
+	public class Patch
+	{
+		// When reverse patched, StringOperation will contain all the
+		// code from the original including the Join() but not the +n
+		//
+		// Basically
+		// var parts = original.Split('-').Reverse().ToArray();
+		// return string.Join("", parts)
+		//
+		[HarmonyReversePatch]
+		[HarmonyPatch(typeof(OriginalClass), "SpecialCalculation")]
+		public static string StringOperation(string original)
+		{
+			// This inner transpiler will be applied to the original and
+			// the result will replace this method
+			//
+			// That will allow this method to have a different signature
+			// than the original and it must match the transpiled result
+			//
+			IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+			{
+				var list = Transpilers.Manipulator(instructions,
+					item => item.opcode == OpCodes.Ldarg_1,
+					item => item.opcode = OpCodes.Ldarg_0
+				).ToList();
+				var mJoin = SymbolExtensions.GetMethodInfo(() => string.Join(null, null));
+				var idx = list.FindIndex(item => item.opcode == OpCodes.Call && item.operand as MethodInfo == mJoin);
+				list.RemoveRange(idx + 1, list.Count - (idx + 1));
+				return list.AsEnumerable();
+			}
+
+			// make compiler happy
+			_ = Transpiler(null);
+			return original;
+		}
+	}
+	// </transpiler>
+}

--- a/Harmony/Documentation/examples/test-all.sh
+++ b/Harmony/Documentation/examples/test-all.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 cd "$(dirname "$0")"
-exec find . -name '*.cs' -print0 | xargs -P "$(nproc || sysctl -n hw.logicalcpu)" -0 -n 1 ./test-one.sh
+exec find . -maxdepth 1 -name '*.cs' -print0 | xargs -P "$(nproc || sysctl -n hw.logicalcpu)" -0 -n 1 ./test-one.sh

--- a/Harmony/Documentation/examples/test-all.sh
+++ b/Harmony/Documentation/examples/test-all.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")"
+exec find . -name '*.cs' -print0 | xargs -P "$(nproc || sysctl -n hw.logicalcpu)" -0 -n 1 ./test-one.sh

--- a/Harmony/Documentation/examples/test-one.sh
+++ b/Harmony/Documentation/examples/test-one.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec csc /nologo /reference:"$(find ../../obj -name 0Harmony.dll | head -n 1)" /target:library /out:/dev/null "$1" $(sed -n 's/.*extra-arg: \(.*\)$/\1/p' "$1")

--- a/Harmony/Documentation/examples/test-one.sh
+++ b/Harmony/Documentation/examples/test-one.sh
@@ -1,2 +1,35 @@
 #!/bin/sh
-exec csc /nologo /reference:"$(find ../../obj -name 0Harmony.dll | head -n 1)" /target:library /out:/dev/null "$1" $(sed -n 's/.*extra-arg: \(.*\)$/\1/p' "$1")
+set -eu
+extra_files=$(sed -n 's/.*extra-file: \(.*\)$/\1/p' "$1")
+harmony=../../obj/Debug/"$netframework"/0Harmony.dll
+
+if command -v csc > /dev/null 2> /dev/null ; then
+	exec csc /nologo /reference:"$harmony" /target:library /out:/dev/null "$1" $extra_files
+elif command -v dotnet > /dev/null 2> /dev/null ; then
+	name=$(basename "$1" .cs)
+	dir=test/"$name"
+	mkdir -p "$dir"
+	cp "$1" $extra_files "$dir"/
+	(
+		cd "$dir"
+		cat <<EOF > "$name".csproj
+			<Project Sdk="Microsoft.NET.Sdk">
+
+				<PropertyGroup>
+					<TargetFramework>$netframework</TargetFramework>
+				</PropertyGroup>
+
+				<ItemGroup>
+					<Reference Include="Harmony">
+						<HintPath>../../$harmony</HintPath>
+					</Reference>
+				</ItemGroup>
+			</Project>
+EOF
+		dotnet build --nologo -v:q
+	)
+	rm -rf "$dir"
+else
+	echo 'No C# compiler detected.'
+	exit 1
+fi

--- a/Harmony/Documentation/examples/utilities.cs
+++ b/Harmony/Documentation/examples/utilities.cs
@@ -1,0 +1,49 @@
+using System;
+using HarmonyLib;
+
+class Example
+{
+	// <example>
+	class Foo
+	{
+		struct Bar
+		{
+			static string secret = "hello";
+
+			public string ModifiedSecret()
+			{
+				return secret.ToUpper();
+			}
+		}
+
+		Bar myBar
+		{
+			get
+			{
+				return new Bar();
+			}
+		}
+
+		public string GetSecret()
+		{
+			return myBar.ModifiedSecret();
+		}
+
+		Foo()
+		{
+		}
+
+		static Foo MakeFoo()
+		{
+			return new Foo();
+		}
+	}
+
+	void Test()
+	{
+		var foo = Traverse.Create<Foo>().Method("MakeFoo").GetValue<Foo>();
+		Traverse.Create(foo).Property("myBar").Field("secret").SetValue("world");
+		Console.WriteLine(foo.GetSecret()); // outputs WORLD
+	}
+	// </example>
+}

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -24,6 +24,7 @@
 		<LogFile>obj/docfx-$(TargetFramework).log</LogFile>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>7.3</LangVersion>
+		<DefaultItemExcludes>$(DefaultItemExcludes);Documentation/**</DefaultItemExcludes>
 	</PropertyGroup>
 
 	<Choose>


### PR DESCRIPTION
- Move all non-trivial pieces of code in the documentation to .cs files
- Reference them using DocFX's `[!code...]` tags
- Ensure that they compile against the built 0Harmony.dll
- Fix the examples where necessary so that they compile successfully
- Test the examples on CI

Here is a diff which illustrates the resulting changes (due to code fixes) in the rendered documentation:
https://github.com/CyberShadow/Harmony/commit/bda0b23dc9329739cd9b19d29fe1ccf03f56a774