### PR TITLE
Fix CodeInstruction Extension IsLdarg for short-form operands

### DIFF
--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -172,8 +172,9 @@ namespace HarmonyLib
 			if ((n.HasValue == false || n.Value == 1) && code.opcode == OpCodes.Ldarg_1) return true;
 			if ((n.HasValue == false || n.Value == 2) && code.opcode == OpCodes.Ldarg_2) return true;
 			if ((n.HasValue == false || n.Value == 3) && code.opcode == OpCodes.Ldarg_3) return true;
-			if (code.opcode != OpCodes.Ldarg && code.opcode != OpCodes.Ldarg_S) return false;
-			return n.HasValue == false || n.Value == ((int)code.operand);
+			if (code.opcode == OpCodes.Ldarg && (n.HasValue == false || n.Value == ((int)code.operand))) return true;
+			if (code.opcode == OpCodes.Ldarg_S && (n.HasValue == false || n.Value == ((Byte)code.operand))) return true;
+			return false;
 		}
 
 		/// <summary>Tests for Ldarga/Ldarga_S</summary>


### PR DESCRIPTION
Ldarg_s needs the operand cast to Byte, not int - InvalidCastException otherwise.

(There are probably more occurrences of this problem, but this is just the one I hit)

Example transpiler simply to catch the exception:
```cs

[HarmonyPatch(typeof(PlaceWorker_PreventInteractionSpotOverlap), nameof(PlaceWorker_PreventInteractionSpotOverlap.AllowsPlacing))]
public static class IgnoreInteractionSpotOverlap {
public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
{
	foreach(var inst in instructions)
	{ 
		try
		{
			bool test = inst.IsLdarg(5);
		}
		catch (Exception e)
		{
			Log.Message($"- {inst}/{inst.operand.GetType()}");
			Log.Message($"- {e}");
		}
		yield return inst;
	}
}
}
```

results:
- ldarg.s 4/System.Byte
- `System.InvalidCastException: Specified cast is not valid.
  at HarmonyLib.CodeInstructionExtensions.IsLdarg (HarmonyLib.CodeInstruction code, System.Nullable`1[T] n) [0x000d1]`