### PR TITLE
Fix lazy enumerable transpilers running multiple times, undo unnecessary exception stack trace preservation changes

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -41,22 +41,6 @@
 		</Otherwise>
 	</Choose>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='net35'">
-		<DefineConstants>NET3_0</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<DefineConstants>NETSTANDARD2_0</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
-		<DefineConstants>NETCOREAPP3_0</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-		<DefineConstants>NETCOREAPP3_1</DefineConstants>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<None Include="..\LICENSE" Pack="true" PackagePath="" />
 		<None Include="..\HarmonyLogo.png" Pack="true" Visible="false" PackagePath="" />

--- a/Harmony/Internal/CodeTranspiler.cs
+++ b/Harmony/Internal/CodeTranspiler.cs
@@ -236,8 +236,9 @@ namespace HarmonyLib
 				instructions = ConvertToGeneralInstructions(transpiler, instructions, out var unassignedValues);
 
 				// remember the order of the original input (for detection of dupped code instructions)
-				var originalInstructions = new List<object>();
-				originalInstructions.AddRange(instructions.Cast<object>());
+				List<object> originalInstructions = null;
+				if (unassignedValues != null)
+					originalInstructions = instructions.Cast<object>().ToList();
 
 				// call the transpiler
 				var parameter = GetTranspilerCallParameters(generator, transpiler, method, instructions);

--- a/Harmony/Internal/CodeTranspiler.cs
+++ b/Harmony/Internal/CodeTranspiler.cs
@@ -206,7 +206,7 @@ namespace HarmonyLib
 			if (type == typeof(IEnumerable<CodeInstruction>))
 			{
 				unassignedValues = null;
-				return enumerable;
+				return enumerable as IList<CodeInstruction> ?? (enumerable as IEnumerable<CodeInstruction> ?? enumerable.Cast<CodeInstruction>()).ToList();
 			}
 			return ConvertInstructionsAndUnassignedValues(type, enumerable, out unassignedValues);
 		}
@@ -249,7 +249,7 @@ namespace HarmonyLib
 					instructions = ConvertToOurInstructions(instructions, typeof(CodeInstruction), originalInstructions, unassignedValues);
 			});
 
-			var result = instructions.Cast<CodeInstruction>().ToList();
+			var result = instructions as List<CodeInstruction> ?? instructions.Cast<CodeInstruction>().ToList();
 			if (argumentShift)
 				StructReturnBuffer.ArgumentShifter(result, method.IsStatic && AccessTools.IsMonoRuntime);
 			return result;

--- a/Harmony/Internal/PatchFunctions.cs
+++ b/Harmony/Internal/PatchFunctions.cs
@@ -156,13 +156,7 @@ namespace HarmonyLib
 			}
 			catch (Exception ex)
 			{
-				var exception = HarmonyException.Create(ex, finalInstructions);
-#if NET3_0
-				AccessTools.PreserveStackTrace(exception);
-				throw exception;
-#else
-				System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
-#endif
+				throw HarmonyException.Create(ex, finalInstructions);
 			}
 			return replacement;
 		}
@@ -197,13 +191,7 @@ namespace HarmonyLib
 			}
 			catch (Exception ex)
 			{
-				var exception = HarmonyException.Create(ex, finalInstructions);
-#if NET3_0
-				AccessTools.PreserveStackTrace(exception);
-				throw exception;
-#else
-				System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
-#endif
+				throw HarmonyException.Create(ex, finalInstructions);
 			}
 
 			PatchTools.RememberObject(standin.method, replacement);

--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -79,13 +79,7 @@ namespace HarmonyLib
 			}
 			catch (AmbiguousMatchException ex)
 			{
-				var exception = new HarmonyException($"Ambiguous match for HarmonyMethod[{attr.Description()}]", ex.InnerException ?? ex);
-#if NET3_0
-				AccessTools.PreserveStackTrace(exception);
-				throw exception;
-#else
-				System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
-#endif
+				throw new HarmonyException($"Ambiguous match for HarmonyMethod[{attr.Description()}]", ex.InnerException ?? ex);
 			}
 
 			return null;

--- a/Harmony/Public/CodeInstruction.cs
+++ b/Harmony/Public/CodeInstruction.cs
@@ -41,8 +41,8 @@ namespace HarmonyLib
 		{
 			opcode = instruction.opcode;
 			operand = instruction.operand;
-			labels = instruction.labels.ToArray().ToList();
-			blocks = instruction.blocks.ToArray().ToList();
+			labels = instruction.labels.ToList();
+			blocks = instruction.blocks.ToList();
 		}
 
 		/// <summary>Clones a CodeInstruction and resets its labels and exception blocks</summary>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -10,18 +10,6 @@
 		<ProjectReference Include="..\Harmony\Harmony.csproj" />
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-		<DefineConstants>NETCOREAPP2_0</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
-		<DefineConstants>NETCOREAPP3_0</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-		<DefineConstants>NETCOREAPP3_1</DefineConstants>
-	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<Optimize>false</Optimize>
 		<DebugType>full</DebugType>

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -998,6 +998,16 @@ namespace HarmonyLibTests.Assets
 		}
 	}
 
+	public static class LazyTranspilerRunsOnce_Class
+	{
+		public static int counter = 0;
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static void Method()
+		{
+		}
+	}
+
 	// disabled - see test case
 	/*
 	public class ClassExceptionFilter

--- a/HarmonyTests/Patching/Transpiling.cs
+++ b/HarmonyTests/Patching/Transpiling.cs
@@ -83,10 +83,10 @@ namespace HarmonyLibTests.Patching
 			var instance = new Harmony("test-lazytranspiler");
 			// Add the transpiler twice.
 			LazyTranspilerRunsOnce_Class.counter = 0;
-			instance.Patch(original, transpiler: new HarmonyMethod(transpiler) { debug = true });
+			instance.Patch(original, transpiler: new HarmonyMethod(transpiler));
 			Assert.AreEqual(LazyTranspilerRunsOnce_Class.counter, 1);
 			LazyTranspilerRunsOnce_Class.counter = 0;
-			instance.Patch(original, transpiler: new HarmonyMethod(transpiler) { debug = true });
+			instance.Patch(original, transpiler: new HarmonyMethod(transpiler));
 			Assert.AreEqual(LazyTranspilerRunsOnce_Class.counter, 2);
 		}
 
@@ -95,6 +95,7 @@ namespace HarmonyLibTests.Patching
 			LazyTranspilerRunsOnce_Class.counter++;
 			foreach (var instruction in instructions)
 				yield return instruction;
+			instructions.ToList(); // just to iterate the instructions again
 		}
 	}
 }


### PR DESCRIPTION
* Undo unnecessary exception stack trace preservation changes, though keep a `RethrowException` utility method
* Remove unnecessary `DefineConstants`
* Fix lazy enumerable transpilers running multiple times if transpiler uses exact same `CodeInstruction` type