### PR TITLE
Proposed Is extension method and optimized MemeberInfo Is/OperandIs overloads

### DIFF
--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -7,7 +8,7 @@ using System.Reflection.Emit;
 namespace HarmonyLib
 {
 	/// <summary>General extensions for common cases</summary>
-	/// 
+	///
 	public static class GeneralExtensions
 	{
 		/// <summary>Joins an enumeration with a value converter and a delimiter to a string</summary>
@@ -113,7 +114,7 @@ namespace HarmonyLib
 	}
 
 	/// <summary>Extensions for <see cref="CodeInstruction"/></summary>
-	/// 
+	///
 	public static class CodeInstructionExtensions
 	{
 		static readonly HashSet<OpCode> loadVarCodes = new HashSet<OpCode>
@@ -143,11 +144,11 @@ namespace HarmonyLib
 			OpCodes.Ldc_I4, OpCodes.Ldc_I4_S, OpCodes.Ldc_I8, OpCodes.Ldc_R4, OpCodes.Ldc_R8
 		};
 
-		/// <summary>Shortcut for testing if the operand is equal to a non-null typed value</summary>
+		/// <summary>Shortcut for testing whether the operand is equal to a non-null value</summary>
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="value">The value</param>
 		/// <returns>True if the operand has the same type and is equal to the value</returns>
-		/// 
+		///
 		public static bool OperandIs(this CodeInstruction code, object value)
 		{
 			if (value == null) throw new ArgumentNullException(nameof(value));
@@ -161,11 +162,48 @@ namespace HarmonyLib
 			return Equals(code.operand, value);
 		}
 
+		/// <summary>Shortcut for testing whether the operand is equal to a non-null value</summary>
+		/// <param name="code">The <see cref="CodeInstruction"/></param>
+		/// <param name="value">The <see cref="MemberInfo"/> value</param>
+		/// <returns>True if the operand is equal to the value</returns>
+		/// <remarks>This is an optimized version of <see cref="OperandIs(CodeInstruction, object)"/> for <see cref="MemberInfo"/></remarks>
+		///
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static bool OperandIs(this CodeInstruction code, MemberInfo value)
+		{
+			if (value == null) throw new ArgumentNullException(nameof(value));
+			return Equals(code.operand, value);
+		}
+
+		/// <summary>Shortcut for <code>code.opcode == opcode &amp;&amp; code.OperandIs(operand)</code></summary>
+		/// <param name="code">The <see cref="CodeInstruction"/></param>
+		/// <param name="opcode">The <see cref="OpCode"/></param>
+		/// <param name="operand">The operand value</param>
+		/// <returns>True if the opcode is equal to the given opcode and the operand has the same type and is equal to the given operand</returns>
+		///
+		public static bool Is(this CodeInstruction code, OpCode opcode, object operand)
+		{
+			return code.opcode == opcode && code.OperandIs(operand);
+		}
+
+		/// <summary>Shortcut for <code>code.opcode == opcode &amp;&amp; code.OperandIs(operand)</code></summary>
+		/// <param name="code">The <see cref="CodeInstruction"/></param>
+		/// <param name="opcode">The <see cref="OpCode"/></param>
+		/// <param name="operand">The <see cref="MemberInfo"/> operand value</param>
+		/// <returns>True if the opcode is equal to the given opcode and the operand is equal to the given operand</returns>
+		/// <remarks>This is an optimized version of <see cref="Is(CodeInstruction, OpCode, object)"/> for <see cref="MemberInfo"/></remarks>
+		///
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static bool Is(this CodeInstruction code, OpCode opcode, MemberInfo operand)
+		{
+			return code.opcode == opcode && code.OperandIs(operand);
+		}
+
 		/// <summary>Tests for any form of Ldarg*</summary>
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="n">The (optional) index</param>
 		/// <returns>True if it matches one of the variations</returns>
-		/// 
+		///
 		public static bool IsLdarg(this CodeInstruction code, int? n = null)
 		{
 			if ((n.HasValue == false || n.Value == 0) && code.opcode == OpCodes.Ldarg_0) return true;
@@ -181,7 +219,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="n">The (optional) index</param>
 		/// <returns>True if it matches one of the variations</returns>
-		/// 
+		///
 		public static bool IsLdarga(this CodeInstruction code, int? n = null)
 		{
 			if (code.opcode != OpCodes.Ldarga && code.opcode != OpCodes.Ldarga_S) return false;
@@ -192,7 +230,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="n">The (optional) index</param>
 		/// <returns>True if it matches one of the variations</returns>
-		/// 
+		///
 		public static bool IsStarg(this CodeInstruction code, int? n = null)
 		{
 			if (code.opcode != OpCodes.Starg && code.opcode != OpCodes.Starg_S) return false;
@@ -203,7 +241,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="variable">The optional local variable</param>
 		/// <returns>True if it matches one of the variations</returns>
-		/// 
+		///
 		public static bool IsLdloc(this CodeInstruction code, LocalBuilder variable = null)
 		{
 			if (loadVarCodes.Contains(code.opcode) == false) return false;
@@ -214,7 +252,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="variable">The optional local variable</param>
 		/// <returns>True if it matches one of the variations</returns>
-		/// 
+		///
 		public static bool IsStloc(this CodeInstruction code, LocalBuilder variable = null)
 		{
 			if (storeVarCodes.Contains(code.opcode) == false) return false;
@@ -225,7 +263,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="label">The label if the instruction is a branch operation or <see langword="null"/> if not</param>
 		/// <returns>True if the instruction branches</returns>
-		/// 
+		///
 		public static bool Branches(this CodeInstruction code, out Label? label)
 		{
 			if (branchCodes.Contains(code.opcode))
@@ -241,7 +279,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="method">The method</param>
 		/// <returns>True if the instruction calls the method or constructor</returns>
-		/// 
+		///
 		public static bool Calls(this CodeInstruction code, MethodInfo method)
 		{
 			if (method == null) throw new ArgumentNullException(nameof(method));
@@ -252,7 +290,7 @@ namespace HarmonyLib
 		/// <summary>Tests if the code instruction loads a constant</summary>
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <returns>True if the instruction loads a constant</returns>
-		/// 
+		///
 		public static bool LoadsConstant(this CodeInstruction code)
 		{
 			return constantLoadingCodes.Contains(code.opcode);
@@ -262,7 +300,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="number">The integer constant</param>
 		/// <returns>True if the instruction loads the constant</returns>
-		/// 
+		///
 		public static bool LoadsConstant(this CodeInstruction code, long number)
 		{
 			var op = code.opcode;
@@ -284,7 +322,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="number">The floating point constant</param>
 		/// <returns>True if the instruction loads the constant</returns>
-		/// 
+		///
 		public static bool LoadsConstant(this CodeInstruction code, double number)
 		{
 			if (code.opcode != OpCodes.Ldc_R4 && code.opcode != OpCodes.Ldc_R8) return false;
@@ -296,7 +334,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="e">The enum</param>
 		/// <returns>True if the instruction loads the constant</returns>
-		/// 
+		///
 		public static bool LoadsConstant(this CodeInstruction code, Enum e)
 		{
 			return code.LoadsConstant(Convert.ToInt64(e));
@@ -307,7 +345,7 @@ namespace HarmonyLib
 		/// <param name="field">The field</param>
 		/// <param name="byAddress">Set to true if the address of the field is loaded</param>
 		/// <returns>True if the instruction loads the field</returns>
-		/// 
+		///
 		public static bool LoadsField(this CodeInstruction code, FieldInfo field, bool byAddress = false)
 		{
 			if (field == null) throw new ArgumentNullException(nameof(field));
@@ -322,7 +360,7 @@ namespace HarmonyLib
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="field">The field</param>
 		/// <returns>True if the instruction stores this field</returns>
-		/// 
+		///
 		public static bool StoresField(this CodeInstruction code, FieldInfo field)
 		{
 			if (field == null) throw new ArgumentNullException(nameof(field));


### PR DESCRIPTION
`code.Is(opcode, operand)` is a shortcut for `code.opcode == opcode && code.OperandIs(operand)`

The `MemberInfo` overloads are just optimized versions for the common use case of comparing with types, fields, methods etc. (when the opcode isn't ldfld, call, etc. so the more specialized extension methods can't be used). They're hidden in IntelliSense to avoid user confusion.