### PR TITLE
Fix Could not load file or assembly 'Mono.Cecil'

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<TargetFrameworks>net35;net45;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Product>Harmony</Product>
@@ -64,7 +64,7 @@
 		<PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="all" Condition="'$(TargetFramework)'=='net35'">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-        <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />
+		<PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -75,8 +75,16 @@
 		<PackageReference Include="MonoMod.Common" Version="20.2.24.2" PrivateAssets="All" />
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
-
-	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Release'">
+    <Target Name="RemoveOldNuGetPackages" BeforeTargets="PreBuildEvent">
+        <PropertyGroup>
+            <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)</WorkingDirectory>
+        </PropertyGroup>
+        <ItemGroup>
+            <OldNugetPackages Include="$(WorkingDirectory)\$(PackageId).*.nupkg"  Exclude="$(WorkingDirectory)\$(PackageId).$(Version).nupkg" />
+        </ItemGroup>
+        <Delete Files="@(OldNugetPackages)" />
+    </Target>
+	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="'$(MSBuildRuntimeType)' == 'Core'">
 		<!-- Merge all dependencies into Harmony whenever it makes sense and whenever possible. -->
 		<PropertyGroup>
 			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
@@ -102,7 +110,7 @@
 		<Delete Files="@(UnnecessaryDependencyFiles)" />
 	</Target>
 
-	<UsingTask TaskName="Zip" TaskFactory="CodeTaskFactory" AssemblyName="Microsoft.Build.Tasks.v12.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+	<UsingTask TaskName="Zip" TaskFactory="CodeTaskFactory" AssemblyName="Microsoft.Build.Tasks.v12.0">
 		<ParameterGroup>
 			<InputDirectory ParameterType="System.String" Required="true" />
 			<TempFile ParameterType="System.String" Required="true" />

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -85,7 +85,8 @@
 		</ItemGroup>
 		<Delete Files="@(OldNugetPackages)" />
 	</Target>
-	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="'$(MSBuildRuntimeType)' == 'Core'">
+
+	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(Configuration)'=='Release'">
 		<!-- Merge all dependencies into Harmony whenever it makes sense and whenever possible. -->
 		<PropertyGroup>
 			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -75,7 +75,7 @@
 		<PackageReference Include="MonoMod.Common" Version="20.2.24.2" PrivateAssets="All" />
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
-	
+
 	<Target Name="RemoveOldNuGetPackages" BeforeTargets="PreBuildEvent">
 		<PropertyGroup>
 			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)</WorkingDirectory>

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -75,15 +75,16 @@
 		<PackageReference Include="MonoMod.Common" Version="20.2.24.2" PrivateAssets="All" />
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
-    <Target Name="RemoveOldNuGetPackages" BeforeTargets="PreBuildEvent">
-        <PropertyGroup>
-            <WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)</WorkingDirectory>
-        </PropertyGroup>
-        <ItemGroup>
-            <OldNugetPackages Include="$(WorkingDirectory)\$(PackageId).*.nupkg"  Exclude="$(WorkingDirectory)\$(PackageId).$(Version).nupkg" />
-        </ItemGroup>
-        <Delete Files="@(OldNugetPackages)" />
-    </Target>
+	
+	<Target Name="RemoveOldNuGetPackages" BeforeTargets="PreBuildEvent">
+		<PropertyGroup>
+			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)</WorkingDirectory>
+		</PropertyGroup>
+		<ItemGroup>
+			<OldNugetPackages Include="$(WorkingDirectory)\$(PackageId).*.nupkg"  Exclude="$(WorkingDirectory)\$(PackageId).$(Version).nupkg" />
+		</ItemGroup>
+		<Delete Files="@(OldNugetPackages)" />
+	</Target>
 	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="'$(MSBuildRuntimeType)' == 'Core'">
 		<!-- Merge all dependencies into Harmony whenever it makes sense and whenever possible. -->
 		<PropertyGroup>

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<TargetFrameworks>net35;net45;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Product>Harmony</Product>
@@ -26,20 +27,6 @@
 		<LangVersion>7.3</LangVersion>
 		<DefaultItemExcludes>$(DefaultItemExcludes);Documentation/**</DefaultItemExcludes>
 	</PropertyGroup>
-
-	<Choose>
-		<When Condition="$(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp'))">
-			<PropertyGroup>
-				<IsCoreOrStandard>true</IsCoreOrStandard>
-			</PropertyGroup>
-		</When>
-		<Otherwise>
-			<PropertyGroup>
-				<IsCoreOrStandard>false</IsCoreOrStandard>
-				<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-			</PropertyGroup>
-		</Otherwise>
-	</Choose>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<DefineConstants>NETSTANDARD2_0</DefineConstants>
@@ -77,7 +64,7 @@
 		<PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="all" Condition="'$(TargetFramework)'=='net35'">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
+        <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -101,7 +88,7 @@
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
 
-	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="!$(IsCoreOrStandard) And '$(Configuration)'=='Release'">
+	<Target Name="ILRepack" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Release'">
 		<!-- Merge all dependencies into Harmony whenever it makes sense and whenever possible. -->
 		<PropertyGroup>
 			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>


### PR DESCRIPTION
Fix https://github.com/pardeike/Harmony/issues/255

`ILRepack.MSBuild.Task` don't support packing netcoreapp when use `MSBuild`, but support `dotnet build`
```
Failed to resolve System.Reflection.BindingFlags
   at Mono.Cecil.Mixin.CheckedResolve(TypeReference self)
   at Mono.Cecil.MetadataBuilder.GetConstantType(TypeReference constant_type, Object constant)
   at Mono.Cecil.MetadataBuilder.AddConstant(IConstantProvider owner, TypeReference type)
   at Mono.Cecil.MetadataBuilder.AddField(FieldDefinition field)
   at Mono.Cecil.MetadataBuilder.AddFields(TypeDefinition type)
   at Mono.Cecil.MetadataBuilder.AddType(TypeDefinition type)
   at Mono.Cecil.MetadataBuilder.AddTypes()
   at Mono.Cecil.MetadataBuilder.BuildTypes()
   at Mono.Cecil.MetadataBuilder.BuildModule()
   at Mono.Cecil.MetadataBuilder.BuildMetadata()
   at Mono.Cecil.ModuleWriter.BuildMetadata(ModuleDefinition module, MetadataBuilder metadata)
   at Mono.Cecil.ModuleWriter.Write(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
   at Mono.Cecil.ModuleWriter.WriteModule(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
   at Mono.Cecil.ModuleDefinition.Write(String fileName, WriterParameters parameters)
   at Mono.Cecil.AssemblyDefinition.Write(String fileName, WriterParameters parameters)
   at ILRepacking.ILRepack.Repack()
   at ILRepack.MSBuild.Task.ILRepack.Execute()	Harmony	D:\Documents\GitHub\Harmony\Harmony\Harmony.csproj	101	

```