### PR TITLE
Make MonoMod.Common a public dependency for .NET Standard / Core

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -85,7 +85,9 @@
 
 	<ItemGroup>
 		<!-- https://dev.azure.com/MonoMod/MonoMod/_packaging?_a=feed&feed=DevBuilds -->
-		<PackageReference Include="MonoMod.Common" Version="20.2.24.2" PrivateAssets="All" />
+		<PackageReference Include="MonoMod.Common" Version="20.2.27.1">
+			<PrivateAssets Condition="!$(IsCoreOrStandard)">All</PrivateAssets>
+		</PackageReference>
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -49,7 +49,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MonoMod.Common" Version="20.2.24.2" PrivateAssets="All" />
+		<PackageReference Include="MonoMod.Common" Version="20.2.27.1" />
 	</ItemGroup>
 
 	<Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,6 @@ steps:
 - task: NuGetCommand@2
   inputs:
     restoreSolution: '$(solution)'
-    feedsToUse: config
-    nugetConfigPath: 'nuget.config'
 
 - task: VSBuild@1
   inputs:

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="MonoMod DevBuilds" value="https://pkgs.dev.azure.com/MonoMod/MonoMod/_packaging/DevBuilds/nuget/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
When using Harmony 2.0 from NuGet for .NET Core, Mono.Cecil and MonoMod.Common cannot be found. This is because:
- `PrivateAssets="All"` was permanently applied to the MonoMod.Common package reference, meaning that the nuspec in the nupkg didn't refer to it at all.
- Mono.Cecil is referenced via MonoMod.Common.
- MonoMod.Common was only available using the devbuild feed.

This PR makes MonoMod.Common a public dependency for the .NET Core (and possible future .NET Standard - if needed) builds of Harmony. .NET Framework support stays completely unchanged.

Beyond this PR, MonoMod.Common is now available on nuget.org - albeit as an unlisted package: https://www.nuget.org/packages/MonoMod.Common  
This means that Harmony can depend on it and anything depending on Harmony can now pull it in without issues *without* anyone consuming MMC by accident when they'd want MonoMod.Utils instead, *but* I'll need to push whatever version of MMC is used by Harmony to nuget.org manually. Poof goes the hope of Harmony bumping the dependency version number completely independently...

Effectively, this PR attempts to fix #255. CC @pengweiqhca for testing