### PR TITLE
Fix issue #275 - Update MMC and add missing InternalsVisibleTo

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -85,7 +85,7 @@
 
 	<ItemGroup>
 		<!-- https://dev.azure.com/MonoMod/MonoMod/_packaging?_a=feed&feed=DevBuilds -->
-		<PackageReference Include="MonoMod.Common" Version="20.3.29.2">
+		<PackageReference Include="MonoMod.Common" Version="20.4.5.1">
 			<PrivateAssets Condition="!$(IsCoreOrStandard)">All</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="ILRepack.MSBuild.Task" Version="2.0.13" PrivateAssets="All" />

--- a/Harmony/Properties/AssemblyInfo.cs
+++ b/Harmony/Properties/AssemblyInfo.cs
@@ -3,4 +3,9 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("HarmonyTests")]
+// MonoMod.Common uses IgnoresAccessChecksTo on its end,
+// but older versions of the .NET runtime bundled with older versions of Windows
+// require Harmony to expose its internals instead.
+// This is only relevant for when MonoMod.Common gets merged into Harmony.
+[assembly: InternalsVisibleTo("MonoMod.Utils.Cil.ILGeneratorProxy")]
 [assembly: Guid("69aee16a-b6e7-4642-8081-3928b32455df")]

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -49,7 +49,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MonoMod.Common" Version="20.3.29.2" />
+		<PackageReference Include="MonoMod.Common" Version="20.4.5.1" />
 	</ItemGroup>
 
 	<Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">


### PR DESCRIPTION
This PR fixes #275 by updating MMC to 20.4.5.1 and adds `[assembly: InternalsVisibleTo("MonoMod.Utils.Cil.ILGeneratorProxy")]` to Harmony's `AssemblyInfo.cs`