### PR TITLE
Clarify AccessTools.Method docs

### DIFF
--- a/docs/api/HarmonyLib.AccessTools.html
+++ b/docs/api/HarmonyLib.AccessTools.html
@@ -3178,8 +3178,7 @@
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">typeColonMethodname</span></td>
-        <td><p>The full name like <code>Namespace.Type:MethodName</code> of the type where the method is declared</p>
-</td>
+        <td><p>The target method in the form <code>TypeFullName:MethodName</code>, where the type name matches a form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <code>Some.Namespace.Type</code>.</p></td>
       </tr>
       <tr>
         <td><span class="xref">System.Type</span>[]</td>


### PR DESCRIPTION
This clarifies the `typeColonMethodname` argument and links to the official docs for the type name format, so users can look up edge cases like nested types.