### PR TITLE
Include type in patched method names for stack traces

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -224,7 +224,7 @@ namespace HarmonyLib
 			if (original == null) throw new ArgumentNullException(nameof(original));
 			var useStructReturnBuffer = StructReturnBuffer.NeedsFix(original);
 
-			var patchName = original.Name + suffix;
+			var patchName = $"{original.DeclaringType?.FullName}.{original.Name}{suffix}";
 			patchName = patchName.Replace("<>", "");
 
 			var parameters = original.GetParameters();


### PR DESCRIPTION
Currently patch methods lose the namespace/type info, so you have error traces like this:
```
at StardewValley.Locations.MovieTheater..ctor() in ...
at load_Patch2()
```

This adds the type to the method name, so stack traces look like this instead:
```
at StardewValley.Locations.MovieTheater..ctor() in ...
at StardewValley.Game1.load_Patch2()
```