### PR TITLE
Make FastInvokeHandler uses params for varargs

### DIFF
--- a/Harmony/Extras/MethodInvoker.cs
+++ b/Harmony/Extras/MethodInvoker.cs
@@ -11,7 +11,7 @@ namespace HarmonyLib
 	/// <param name="target">The instance</param>
 	/// <param name="parameters">The method parameters</param>
 	/// <returns>The method result</returns>
-	public delegate object FastInvokeHandler(object target, object[] parameters);
+	public delegate object FastInvokeHandler(object target, params object[] parameters);
 
 	/// <summary>A helper class to invoke method with delegates</summary>
 	public static class MethodInvoker

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -964,7 +964,7 @@ namespace HarmonyLib
 		public static void RethrowException(Exception exception)
 		{
 #if NET35
-			_ = PrepForRemoting(exception, new object[0]);
+			_ = PrepForRemoting(exception);
 #else
 			System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
 #endif


### PR DESCRIPTION
Convenience change for MethodInvoker

This is a binary-compatible change: https://github.com/ltrzesniewski/dotnet-runtime/blob/master/docs/coding-guidelines/breaking-change-rules.md#signatures (method signature unchanged, just adds the `ParamArrayAttribute` attribute to parameters arg)