### PR TITLE
More AccessTools/injected delegate work

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -503,7 +503,13 @@ namespace HarmonyLib
 									}
 								}
 
-								emitter.Emit(OpCodes.Ldftn, methodInfo);
+								if (!methodInfo.IsStatic && (harmonyMethod.virtualDelegate ?? true))
+								{
+									emitter.Emit(OpCodes.Dup);
+									emitter.Emit(OpCodes.Ldvirtftn, methodInfo);
+								}
+								else
+									emitter.Emit(OpCodes.Ldftn, methodInfo);
 								emitter.Emit(OpCodes.Newobj, delegateConstructor);
 								continue;
 							}

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -61,14 +61,31 @@ namespace HarmonyLib
 		Snapshot
 	}
 
-	/// <summary>Specifies the type of method</summary>
+	/// <summary>Specifies the type of method binding used during a method call (method call dispatching mechanics)</summary>
 	///
-	public enum MethodInheritance
+	public enum MethodBinding
 	{
-		/// <summary>Call the method using dynamic dispatching like with oridinary virtual/override mechanics</summary>
-		Virtual,
+		/// <summary>Call the method using dynamic dispatching like with ordinary virtual/override mechanics</summary>
+		/// <remarks>
+		/// <para>
+		/// a.k.a. late binding or dynamic binding, this directly corresponds with the <see cref="System.Reflection.Emit.OpCodes.Callvirt"/> instruction.
+		/// </para>
+		/// <para>
+		/// For virtual methods (including overriden methods), the instance type's most-derived/overriden implementation of the method is called.
+		/// For non-virtual methods, same behavior as <see cref="Call"/>: the exact specified method implementation is called.
+		/// </para>
+		/// </remarks>
+		CallVirtually,
 		/// <summary>Call the specified method only, do not dispatch dynamically</summary>
-		None
+		/// <remarks>
+		/// <para>
+		/// a.k.a. early binding or static binding, this directly corresponds with the <see cref="System.Reflection.Emit.OpCodes.Call"/> instruction.
+		/// </para>
+		/// <para>
+		/// For both virtual and non-virtual methods, the exact specified method implementation is called.
+		/// </para>
+		/// </remarks>
+		Call
 	}
 
 	/// <summary>The base class for all Harmony annotations (not meant to be used directly)</summary>
@@ -352,46 +369,46 @@ namespace HarmonyLib
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		///
-		public HarmonyDelegate(Type declaringType, MethodInheritance methodInheritance)
+		public HarmonyDelegate(Type declaringType, MethodBinding methodBinding)
 			: base(declaringType, MethodType.Normal)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		///
-		public HarmonyDelegate(Type declaringType, MethodInheritance methodInheritance, params Type[] argumentTypes)
+		public HarmonyDelegate(Type declaringType, MethodBinding methodBinding, params Type[] argumentTypes)
 			: base(declaringType, MethodType.Normal, argumentTypes)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		/// <param name="argumentVariations">Array of <see cref="ArgumentType"/></param>
 		///
-		public HarmonyDelegate(Type declaringType, MethodInheritance methodInheritance, Type[] argumentTypes, ArgumentType[] argumentVariations)
+		public HarmonyDelegate(Type declaringType, MethodBinding methodBinding, Type[] argumentTypes, ArgumentType[] argumentVariations)
 			: base(declaringType, MethodType.Normal, argumentTypes, argumentVariations)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
 		/// <param name="methodName">The name of the method, property or constructor to patch</param>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		///
-		public HarmonyDelegate(Type declaringType, string methodName, MethodInheritance methodInheritance)
+		public HarmonyDelegate(Type declaringType, string methodName, MethodBinding methodBinding)
 			: base(declaringType, methodName, MethodType.Normal)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -417,41 +434,41 @@ namespace HarmonyLib
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="methodName">The name of the method, property or constructor to patch</param>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		///
-		public HarmonyDelegate(string methodName, MethodInheritance methodInheritance)
+		public HarmonyDelegate(string methodName, MethodBinding methodBinding)
 			: base(methodName, MethodType.Normal)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies call dispatching mechanics for the delegate</summary>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		///
-		public HarmonyDelegate(MethodInheritance methodInheritance)
+		public HarmonyDelegate(MethodBinding methodBinding)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		///
-		public HarmonyDelegate(MethodInheritance methodInheritance, params Type[] argumentTypes)
+		public HarmonyDelegate(MethodBinding methodBinding, params Type[] argumentTypes)
 			: base(MethodType.Normal, argumentTypes)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
-		/// <param name="methodInheritance">The <see cref="MethodInheritance"/></param>
+		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		/// <param name="argumentVariations">An array of <see cref="ArgumentType"/></param>
 		///
-		public HarmonyDelegate(MethodInheritance methodInheritance, Type[] argumentTypes, ArgumentType[] argumentVariations)
+		public HarmonyDelegate(MethodBinding methodBinding, Type[] argumentTypes, ArgumentType[] argumentVariations)
 			: base(MethodType.Normal, argumentTypes, argumentVariations)
 		{
-			info.virtualDelegate = methodInheritance == MethodInheritance.Virtual;
+			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -988,7 +988,7 @@ namespace HarmonyLib
 				var delegateParameters = delegateType.GetMethod("Invoke").GetParameters();
 				if (delegateParameters.Length == 0)
 				{
-					// Following should throw the ArgumentException with the proper message string.
+					// Following should throw an ArgumentException with the proper message string.
 					_ = Delegate.CreateDelegate(typeof(DelegateType), method);
 					// But in case it doesn't...
 					throw new ArgumentException("Invalid delegate type");
@@ -1069,7 +1069,7 @@ namespace HarmonyLib
 			// but this has undefined behavior, so disallow it.
 			if (!declaringType.IsInstanceOfType(instance))
 			{
-				// Following should throw the ArgumentException with the proper message string.
+				// Following should throw an ArgumentException with the proper message string.
 				_ = Delegate.CreateDelegate(typeof(DelegateType), instance, method);
 				// But in case it doesn't...
 				throw new ArgumentException("Invalid delegate type");

--- a/HarmonyTests/Patching/Arguments.cs
+++ b/HarmonyTests/Patching/Arguments.cs
@@ -130,7 +130,7 @@ namespace HarmonyLibTests
 		}
 
 		[Test]
-		public void Test_InjectDelegateForClass()
+		public void Test_InjectBaseDelegateForClass()
 		{
 			var instance = new InjectDelegateClass() { pre = "{", post = "}" };
 			instance.Method(123);
@@ -143,7 +143,7 @@ namespace HarmonyLibTests
 			Assert.AreEqual(1, patches.Count);
 
 			instance.Method(123);
-			Assert.AreEqual("{patch:456}", InjectDelegateClassPatch.result);
+			Assert.AreEqual("{patch:456} | [{patch:456}]", InjectDelegateClassPatch.result);
 		}
 
 		[Test]

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -1076,16 +1076,19 @@ namespace HarmonyLibTests.Assets
 	[HarmonyPatch(typeof(InjectDelegateClass), "Method")]
 	public class InjectDelegateClassPatch
 	{
-		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod")]
+		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod", MethodBinding.Call)]
 		public delegate string TestDelegate(ref string s, int n);
+
+		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod", MethodBinding.CallVirtually)]
+		public delegate string TestVirtualDelegate(ref string s, int n);
 
 		public static string result = "";
 
-		public static bool Prefix(TestDelegate baseSomeMethod, ref int n)
+		public static bool Prefix(TestDelegate baseSomeMethod, TestVirtualDelegate virtualBaseSomeMethod, ref int n)
 		{
 			n = 456;
 			var s = "patch";
-			result = baseSomeMethod(ref s, n);
+			result = baseSomeMethod(ref s, n) + " | " + virtualBaseSomeMethod(ref s, n);
 			return false;
 		}
 	}

--- a/HarmonyTests/Tools/Assets/AccessToolsClass.cs
+++ b/HarmonyTests/Tools/Assets/AccessToolsClass.cs
@@ -82,6 +82,7 @@ namespace HarmonyLibTests.Assets
 		public class Base : IInterface
 		{
 			public int x;
+
 			public virtual string Test(int n, ref float f)
 			{
 				return $"base test {n} {++f} {++x}";
@@ -99,6 +100,7 @@ namespace HarmonyLibTests.Assets
 		public struct Struct : IInterface
 		{
 			public int x;
+
 			public string Test(int n, ref float f)
 			{
 				return $"struct result {n} {++f} {++x}";
@@ -106,6 +108,7 @@ namespace HarmonyLibTests.Assets
 		}
 
 		public static int x;
+
 		public static string Test(int n, ref float f)
 		{
 			return $"static test {n} {++f} {++x}";

--- a/HarmonyTests/Tools/Assets/AccessToolsClass.cs
+++ b/HarmonyTests/Tools/Assets/AccessToolsClass.cs
@@ -72,7 +72,7 @@ namespace HarmonyLibTests.Assets
 	{
 	}
 
-	public static class AccessToolsCreateDelegate
+	public static class AccessToolsMethodDelegate
 	{
 		public interface IInterface
 		{
@@ -115,7 +115,7 @@ namespace HarmonyLibTests.Assets
 		}
 	}
 
-	public static class AccessToolsCreateHarmonyDelegate
+	public static class AccessToolsHarmonyDelegate
 	{
 		public class Foo
 		{

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -290,93 +290,127 @@ namespace HarmonyLibTests
 			Assert.AreEqual(newValue, fieldInfo.GetValue(instance));
 		}
 
+		private static readonly MethodInfo interfaceTest = typeof(IInterface).GetMethod("Test");
+		private static readonly MethodInfo baseTest = typeof(Base).GetMethod("Test");
+		private static readonly MethodInfo derivedTest = typeof(Derived).GetMethod("Test");
+		private static readonly MethodInfo structTest = typeof(Struct).GetMethod("Test");
+		private static readonly MethodInfo staticTest = typeof(AccessToolsCreateDelegate).GetMethod("Test");
+
 		[Test]
-		public void Test_AccessTools_CreateDelegate()
+		public void Test_AccessTools_CreateDelegate_ClosedInstanceDelegates()
 		{
-			float f;
-			var interfaceTest = typeof(IInterface).GetMethod("Test");
-			var baseTest = typeof(Base).GetMethod("Test");
-			var derivedTest = typeof(Derived).GetMethod("Test");
-			var structTest = typeof(Struct).GetMethod("Test");
-			var staticTest = typeof(AccessToolsCreateDelegate).GetMethod("Test");
+			var f = 789f;
+			var baseInstance = new Base();
+			var derivedInstance = new Derived();
+			var structInstance = new Struct();
+			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<MethodDel>(baseTest, baseInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("base test 456 791 2", AccessTools.CreateDelegate<MethodDel>(baseTest, baseInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("derived test 456 792 1", AccessTools.CreateDelegate<MethodDel>(baseTest, derivedInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("base test 456 793 2", AccessTools.CreateDelegate<MethodDel>(baseTest, derivedInstance, virtualCall: false)(456, ref f));
+			// derivedTest => baseTest automatically for virtual calls
+			Assert.AreEqual("base test 456 794 3", AccessTools.CreateDelegate<MethodDel>(derivedTest, baseInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(derivedTest, baseInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("derived test 456 795 3", AccessTools.CreateDelegate<MethodDel>(derivedTest, derivedInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("derived test 456 796 4", AccessTools.CreateDelegate<MethodDel>(derivedTest, derivedInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("struct result 456 797 1", AccessTools.CreateDelegate<MethodDel>(structTest, structInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("struct result 456 798 1", AccessTools.CreateDelegate<MethodDel>(structTest, structInstance, virtualCall: false)(456, ref f));
+		}
 
-			// Closed instance method delegates
-			f = 789f;
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<MethodDel>(baseTest, new Base(), virtualCall: true)(456, ref f));
-			Assert.AreEqual("base test 456 791 1", AccessTools.CreateDelegate<MethodDel>(baseTest, new Base(), virtualCall: false)(456, ref f));
-			Assert.AreEqual("derived test 456 792 1", AccessTools.CreateDelegate<MethodDel>(baseTest, new Derived(), virtualCall: true)(456, ref f));
-			Assert.AreEqual("base test 456 793 1", AccessTools.CreateDelegate<MethodDel>(baseTest, new Derived(), virtualCall: false)(456, ref f));
-			Assert.AreEqual("base test 456 794 1", AccessTools.CreateDelegate<MethodDel>(derivedTest, new Base(), virtualCall: true)(456, ref f)); // derivedTest => baseTest automatically for virtual calls
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(derivedTest, new Base(), virtualCall: false)(456, ref f));
-			Assert.AreEqual("derived test 456 795 1", AccessTools.CreateDelegate<MethodDel>(derivedTest, new Derived(), virtualCall: true)(456, ref f));
-			Assert.AreEqual("derived test 456 796 1", AccessTools.CreateDelegate<MethodDel>(derivedTest, new Derived(), virtualCall: false)(456, ref f));
-			Assert.AreEqual("struct result 456 797 1", AccessTools.CreateDelegate<MethodDel>(structTest, new Struct(), virtualCall: true)(456, ref f));
-			Assert.AreEqual("struct result 456 798 1", AccessTools.CreateDelegate<MethodDel>(structTest, new Struct(), virtualCall: false)(456, ref f));
+		[Test]
+		public void Test_AccessTools_CreateDelegate_ClosedInstanceDelegates_InterfaceMethod()
+		{
+			var f = 789f;
+			var baseInstance = new Base();
+			var derivedInstance = new Derived();
+			var structInstance = new Struct();
+			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, baseInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, baseInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, derivedInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, derivedInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("struct result 456 792 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, structInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, structInstance, virtualCall: false)(456, ref f));
+		}
 
-			// Closed instance method delegates where method is an interface method
-			f = 789f;
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, new Base(), virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, new Base(), virtualCall: false)(456, ref f));
-			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, new Derived(), virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, new Derived(), virtualCall: false)(456, ref f));
-			Assert.AreEqual("struct result 456 792 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, new Struct(), virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, new Struct(), virtualCall: false)(456, ref f));
+		[Test]
+		public void Test_AccessTools_CreateDelegate_OpenInstanceDelegates()
+		{
+			var f = 789f;
+			var baseInstance = new Base();
+			var derivedInstance = new Derived();
+			var structInstance = new Struct();
+			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(baseInstance, 456, ref f));
+			Assert.AreEqual("base test 456 791 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(derivedInstance, 456, ref f));
+			Assert.AreEqual("base test 456 793 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(derivedInstance, 456, ref f));
+			// derivedTest => baseTest automatically for virtual calls
+			Assert.AreEqual("base test 456 794 3", AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 795 3", AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
+			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest)(baseInstance, 456, ref f); // expected compile error
+			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f); // expected compile error
+			Assert.AreEqual("derived test 456 796 4", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 797 5", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 798 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: true)(structInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 799 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: false)(structInstance, 456, ref f));
+		}
 
-			// Open instance method delegates
-			f = 789f;
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(new Base(), 456, ref f));
-			Assert.AreEqual("base test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(new Base(), 456, ref f));
-			Assert.AreEqual("derived test 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(new Derived(), 456, ref f));
-			Assert.AreEqual("base test 456 793 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(new Derived(), 456, ref f));
-			Assert.AreEqual("base test 456 794 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(new Base(), 456, ref f)); // derivedTest => baseTest automatically for virtual calls
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(new Base(), 456, ref f)); // must use OpenMethodDel<Derived>
-			Assert.AreEqual("derived test 456 795 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(new Derived(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(new Derived(), 456, ref f)); // must use OpenMethodDel<Derived>
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest)(new Base(), 456, ref f); // expected compile error
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(new Base(), 456, ref f); // expected compile error
-			Assert.AreEqual("derived test 456 796 1", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: true)(new Derived(), 456, ref f));
-			Assert.AreEqual("derived test 456 797 1", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(new Derived(), 456, ref f));
-			Assert.AreEqual("struct result 456 798 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: true)(new Struct(), 456, ref f));
-			Assert.AreEqual("struct result 456 799 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: false)(new Struct(), 456, ref f));
+		[Test]
+		public void Test_AccessTools_CreateDelegate_OpenInstanceDelegates_DelegateInterfaceInstanceType()
+		{
+			var f = 789f;
+			var baseInstance = new Base();
+			var derivedInstance = new Derived();
+			var structInstance = new Struct();
+			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("base test 456 792 2", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 793 2", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 794 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: true)(structInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: false)(structInstance, 456, ref f));
+		}
 
-			// Open instance method delegates where delegate instance type is an interface
-			f = 789f;
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(new Base(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(new Base(), 456, ref f));
-			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(new Derived(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(new Derived(), 456, ref f));
-			Assert.AreEqual("base test 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(new Base(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(new Base(), 456, ref f));
-			Assert.AreEqual("derived test 456 793 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(new Derived(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(new Derived(), 456, ref f));
-			Assert.AreEqual("struct result 456 794 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: true)(new Struct(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: false)(new Struct(), 456, ref f));
+		[Test]
+		public void Test_AccessTools_CreateDelegate_OpenInstanceDelegates_InterfaceMethod()
+		{
+			var f = 789f;
+			var baseInstance = new Base();
+			var derivedInstance = new Derived();
+			var structInstance = new Struct();
+			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(structInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(structInstance, 456, ref f));
+			Assert.AreEqual("base test 456 793 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 794 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
+			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f)); // expected compile error
+			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f)); // expected compile error
+			Assert.AreEqual("derived test 456 795 3", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 796 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: true)(structInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: false)(structInstance, 456, ref f));
+		}
 
-			// Open instance method delegates where method is an interface method
-			f = 789f;
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(new Base(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(new Base(), 456, ref f));
-			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(new Derived(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(new Derived(), 456, ref f));
-			Assert.AreEqual("struct result 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(new Struct(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(new Struct(), 456, ref f));
-			Assert.AreEqual("base test 456 793 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(new Base(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(new Base(), 456, ref f));
-			Assert.AreEqual("derived test 456 794 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(new Derived(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(new Derived(), 456, ref f));
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(new Base(), 456, ref f)); // expected compile error
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(new Base(), 456, ref f)); // expected compile error
-			Assert.AreEqual("derived test 456 795 1", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(new Derived(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(new Derived(), 456, ref f));
-			Assert.AreEqual("struct result 456 796 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: true)(new Struct(), 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: false)(new Struct(), 456, ref f));
-
-			// Static method delegates
-			f = 789f;
+		[Test]
+		public void Test_AccessTools_CreateDelegate_StaticDelegates_InterfaceMethod()
+		{
+			var f = 789f;
 			Assert.AreEqual("static test 456 790 1", AccessTools.CreateDelegate<MethodDel>(staticTest)(456, ref f));
-			Assert.AreEqual("static test 456 791 2", AccessTools.CreateDelegate<MethodDel>(staticTest, new Base(), virtualCall: false)(456, ref f)); // instance and virtualCall args are ignored
+			// instance and virtualCall args are ignored
+			Assert.AreEqual("static test 456 791 2", AccessTools.CreateDelegate<MethodDel>(staticTest, new Base(), virtualCall: false)(456, ref f));
+		}
 
-			// Invalid delegates
+		[Test]
+		public void Test_AccessTools_CreateDelegate_InvalidDelegates()
+		{
 			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Action>(interfaceTest));
 			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Func<bool>>(baseTest));
 			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Action<string>>(derivedTest));

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using static HarmonyLibTests.Assets.AccessToolsCreateDelegate;
+using static HarmonyLibTests.Assets.AccessToolsMethodDelegate;
 
 namespace HarmonyLibTests
 {
@@ -294,137 +294,137 @@ namespace HarmonyLibTests
 		private static readonly MethodInfo baseTest = typeof(Base).GetMethod("Test");
 		private static readonly MethodInfo derivedTest = typeof(Derived).GetMethod("Test");
 		private static readonly MethodInfo structTest = typeof(Struct).GetMethod("Test");
-		private static readonly MethodInfo staticTest = typeof(AccessToolsCreateDelegate).GetMethod("Test");
+		private static readonly MethodInfo staticTest = typeof(AccessToolsMethodDelegate).GetMethod("Test");
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_ClosedInstanceDelegates()
+		public void Test_AccessTools_MethodDelegate_ClosedInstanceDelegates()
 		{
 			var f = 789f;
 			var baseInstance = new Base();
 			var derivedInstance = new Derived();
 			var structInstance = new Struct();
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<MethodDel>(baseTest, baseInstance, virtualCall: true)(456, ref f));
-			Assert.AreEqual("base test 456 791 2", AccessTools.CreateDelegate<MethodDel>(baseTest, baseInstance, virtualCall: false)(456, ref f));
-			Assert.AreEqual("derived test 456 792 1", AccessTools.CreateDelegate<MethodDel>(baseTest, derivedInstance, virtualCall: true)(456, ref f));
-			Assert.AreEqual("base test 456 793 2", AccessTools.CreateDelegate<MethodDel>(baseTest, derivedInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("base test 456 790 1", AccessTools.MethodDelegate<MethodDel>(baseTest, baseInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("base test 456 791 2", AccessTools.MethodDelegate<MethodDel>(baseTest, baseInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("derived test 456 792 1", AccessTools.MethodDelegate<MethodDel>(baseTest, derivedInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("base test 456 793 2", AccessTools.MethodDelegate<MethodDel>(baseTest, derivedInstance, virtualCall: false)(456, ref f));
 			// derivedTest => baseTest automatically for virtual calls
-			Assert.AreEqual("base test 456 794 3", AccessTools.CreateDelegate<MethodDel>(derivedTest, baseInstance, virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(derivedTest, baseInstance, virtualCall: false)(456, ref f));
-			Assert.AreEqual("derived test 456 795 3", AccessTools.CreateDelegate<MethodDel>(derivedTest, derivedInstance, virtualCall: true)(456, ref f));
-			Assert.AreEqual("derived test 456 796 4", AccessTools.CreateDelegate<MethodDel>(derivedTest, derivedInstance, virtualCall: false)(456, ref f));
-			Assert.AreEqual("struct result 456 797 1", AccessTools.CreateDelegate<MethodDel>(structTest, structInstance, virtualCall: true)(456, ref f));
-			Assert.AreEqual("struct result 456 798 1", AccessTools.CreateDelegate<MethodDel>(structTest, structInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("base test 456 794 3", AccessTools.MethodDelegate<MethodDel>(derivedTest, baseInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<MethodDel>(derivedTest, baseInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("derived test 456 795 3", AccessTools.MethodDelegate<MethodDel>(derivedTest, derivedInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("derived test 456 796 4", AccessTools.MethodDelegate<MethodDel>(derivedTest, derivedInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("struct result 456 797 1", AccessTools.MethodDelegate<MethodDel>(structTest, structInstance, virtualCall: true)(456, ref f));
+			Assert.AreEqual("struct result 456 798 1", AccessTools.MethodDelegate<MethodDel>(structTest, structInstance, virtualCall: false)(456, ref f));
 		}
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_ClosedInstanceDelegates_InterfaceMethod()
+		public void Test_AccessTools_MethodDelegate_ClosedInstanceDelegates_InterfaceMethod()
 		{
 			var f = 789f;
 			var baseInstance = new Base();
 			var derivedInstance = new Derived();
 			var structInstance = new Struct();
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, baseInstance, virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, baseInstance, virtualCall: false)(456, ref f));
-			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, derivedInstance, virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, derivedInstance, virtualCall: false)(456, ref f));
-			Assert.AreEqual("struct result 456 792 1", AccessTools.CreateDelegate<MethodDel>(interfaceTest, structInstance, virtualCall: true)(456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<MethodDel>(interfaceTest, structInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("base test 456 790 1", AccessTools.MethodDelegate<MethodDel>(interfaceTest, baseInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<MethodDel>(interfaceTest, baseInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("derived test 456 791 1", AccessTools.MethodDelegate<MethodDel>(interfaceTest, derivedInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<MethodDel>(interfaceTest, derivedInstance, virtualCall: false)(456, ref f));
+			Assert.AreEqual("struct result 456 792 1", AccessTools.MethodDelegate<MethodDel>(interfaceTest, structInstance, virtualCall: true)(456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<MethodDel>(interfaceTest, structInstance, virtualCall: false)(456, ref f));
 		}
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_OpenInstanceDelegates()
+		public void Test_AccessTools_MethodDelegate_OpenInstanceDelegates()
 		{
 			var f = 789f;
 			var baseInstance = new Base();
 			var derivedInstance = new Derived();
 			var structInstance = new Struct();
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(baseInstance, 456, ref f));
-			Assert.AreEqual("base test 456 791 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(baseInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(derivedInstance, 456, ref f));
-			Assert.AreEqual("base test 456 793 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("base test 456 790 1", AccessTools.MethodDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(baseInstance, 456, ref f));
+			Assert.AreEqual("base test 456 791 2", AccessTools.MethodDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 792 1", AccessTools.MethodDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: true)(derivedInstance, 456, ref f));
+			Assert.AreEqual("base test 456 793 2", AccessTools.MethodDelegate<OpenMethodDel<Base>>(baseTest, virtualCall: false)(derivedInstance, 456, ref f));
 			// derivedTest => baseTest automatically for virtual calls
-			Assert.AreEqual("base test 456 794 3", AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(baseInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 795 3", AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest)(baseInstance, 456, ref f); // expected compile error
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f); // expected compile error
-			Assert.AreEqual("derived test 456 796 4", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 797 5", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
-			Assert.AreEqual("struct result 456 798 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: true)(structInstance, 456, ref f));
-			Assert.AreEqual("struct result 456 799 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: false)(structInstance, 456, ref f));
+			Assert.AreEqual("base test 456 794 3", AccessTools.MethodDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 795 3", AccessTools.MethodDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<Base>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
+			// AccessTools.MethodDelegate<OpenMethodDel<Derived>>(derivedTest)(baseInstance, 456, ref f); // expected compile error
+			// AccessTools.MethodDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f); // expected compile error
+			Assert.AreEqual("derived test 456 796 4", AccessTools.MethodDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 797 5", AccessTools.MethodDelegate<OpenMethodDel<Derived>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 798 1", AccessTools.MethodDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: true)(structInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 799 1", AccessTools.MethodDelegate<OpenMethodDel<Struct>>(structTest, virtualCall: false)(structInstance, 456, ref f));
 		}
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_OpenInstanceDelegates_DelegateInterfaceInstanceType()
+		public void Test_AccessTools_MethodDelegate_OpenInstanceDelegates_DelegateInterfaceInstanceType()
 		{
 			var f = 789f;
 			var baseInstance = new Base();
 			var derivedInstance = new Derived();
 			var structInstance = new Struct();
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(baseInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(baseInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(derivedInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(derivedInstance, 456, ref f));
-			Assert.AreEqual("base test 456 792 2", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(baseInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 793 2", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
-			Assert.AreEqual("struct result 456 794 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: true)(structInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: false)(structInstance, 456, ref f));
+			Assert.AreEqual("base test 456 790 1", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 791 1", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(baseTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("base test 456 792 2", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 793 2", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(derivedTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 794 1", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: true)(structInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(structTest, virtualCall: false)(structInstance, 456, ref f));
 		}
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_OpenInstanceDelegates_InterfaceMethod()
+		public void Test_AccessTools_MethodDelegate_OpenInstanceDelegates_InterfaceMethod()
 		{
 			var f = 789f;
 			var baseInstance = new Base();
 			var derivedInstance = new Derived();
 			var structInstance = new Struct();
-			Assert.AreEqual("base test 456 790 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 791 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
-			Assert.AreEqual("struct result 456 792 1", AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(structInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(structInstance, 456, ref f));
-			Assert.AreEqual("base test 456 793 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f));
-			Assert.AreEqual("derived test 456 794 2", AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f)); // expected compile error
-			// AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f)); // expected compile error
-			Assert.AreEqual("derived test 456 795 3", AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
-			Assert.AreEqual("struct result 456 796 1", AccessTools.CreateDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: true)(structInstance, 456, ref f));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: false)(structInstance, 456, ref f));
+			Assert.AreEqual("base test 456 790 1", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 791 1", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 792 1", AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: true)(structInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<IInterface>>(interfaceTest, virtualCall: false)(structInstance, 456, ref f));
+			Assert.AreEqual("base test 456 793 2", AccessTools.MethodDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f));
+			Assert.AreEqual("derived test 456 794 2", AccessTools.MethodDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<Base>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
+			// AccessTools.MethodDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(baseInstance, 456, ref f)); // expected compile error
+			// AccessTools.MethodDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(baseInstance, 456, ref f)); // expected compile error
+			Assert.AreEqual("derived test 456 795 3", AccessTools.MethodDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: true)(derivedInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<Derived>>(interfaceTest, virtualCall: false)(derivedInstance, 456, ref f));
+			Assert.AreEqual("struct result 456 796 1", AccessTools.MethodDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: true)(structInstance, 456, ref f));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<OpenMethodDel<Struct>>(interfaceTest, virtualCall: false)(structInstance, 456, ref f));
 		}
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_StaticDelegates_InterfaceMethod()
+		public void Test_AccessTools_MethodDelegate_StaticDelegates_InterfaceMethod()
 		{
 			var f = 789f;
-			Assert.AreEqual("static test 456 790 1", AccessTools.CreateDelegate<MethodDel>(staticTest)(456, ref f));
+			Assert.AreEqual("static test 456 790 1", AccessTools.MethodDelegate<MethodDel>(staticTest)(456, ref f));
 			// instance and virtualCall args are ignored
-			Assert.AreEqual("static test 456 791 2", AccessTools.CreateDelegate<MethodDel>(staticTest, new Base(), virtualCall: false)(456, ref f));
+			Assert.AreEqual("static test 456 791 2", AccessTools.MethodDelegate<MethodDel>(staticTest, new Base(), virtualCall: false)(456, ref f));
 		}
 
 		[Test]
-		public void Test_AccessTools_CreateDelegate_InvalidDelegates()
+		public void Test_AccessTools_MethodDelegate_InvalidDelegates()
 		{
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Action>(interfaceTest));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Func<bool>>(baseTest));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Action<string>>(derivedTest));
-			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.CreateDelegate<Func<int, float, string>>(structTest));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<Action>(interfaceTest));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<Func<bool>>(baseTest));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<Action<string>>(derivedTest));
+			_ = Assert.Throws(typeof(ArgumentException), () => AccessTools.MethodDelegate<Func<int, float, string>>(structTest));
 		}
 
 		delegate string MethodDel(int n, ref float f);
 		delegate string OpenMethodDel<T>(T instance, int n, ref float f);
 
 		[Test]
-		public void Test_AccessTools_CreateHarmonyDelegate()
+		public void Test_AccessTools_HarmonyDelegate()
 		{
-			var someMethod = AccessTools.CreateHarmonyDelegate<AccessToolsCreateHarmonyDelegate.FooSomeMethod>();
-			var foo = new AccessToolsCreateHarmonyDelegate.Foo();
+			var someMethod = AccessTools.HarmonyDelegate<AccessToolsHarmonyDelegate.FooSomeMethod>();
+			var foo = new AccessToolsHarmonyDelegate.Foo();
 			Assert.AreEqual("[test]", someMethod(foo, "test"));
 		}
 	}


### PR DESCRIPTION
As discussed in discord...

- Implement virtual delegate injection
- Default to virtual calling
- `AccessTools.CreateDelegate` => `AccessTools.MethodDelegate`, `AccessTools.CreateHarmonyDelegate` => `AccessTools.HarmonyDelegate`
- `MethodInheritance.Virtual/None` => `MethodBinding.CallVirtually/Call`
- Add optional `instance` param to `AccessTools.HarmonyDelegate`
- Split up `AccessTools` delegate tests. This is done partly for organizational reasons (and to make room for more edge case tests), and partly to demonstrate mutability of passed non-struct instances.
- Improve some XML docs