### PR TITLE
Mark Memory and PatchInfo internal

### DIFF
--- a/Harmony/Internal/Memory.cs
+++ b/Harmony/Internal/Memory.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 namespace HarmonyLib
 {
 	/// <summary>A low level memory helper</summary>
-	public static class Memory
+	internal static class Memory
 	{
 		/// <summary>Mark method for no inlining (currently only works on Mono)</summary>
 		/// <param name="method">The method/constructor to change</param>

--- a/Harmony/Public/Patch.cs
+++ b/Harmony/Public/Patch.cs
@@ -85,7 +85,7 @@ namespace HarmonyLib
 	/// <summary>Serializable patch information</summary>
 	/// 
 	[Serializable]
-	public class PatchInfo
+	internal class PatchInfo
 	{
 		/// <summary>Prefixes as an array of <see cref="Patch"/></summary>
 		/// 


### PR DESCRIPTION
They're used internally and not exposed through any public API.