### PR TITLE
More HarmonyDelegate tweaks

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -503,7 +503,7 @@ namespace HarmonyLib
 									}
 								}
 
-								if (!methodInfo.IsStatic && harmonyMethod.virtualDelegate)
+								if (methodInfo.IsStatic == false && harmonyMethod.nonVirtualDelegate == false)
 								{
 									emitter.Emit(OpCodes.Dup);
 									emitter.Emit(OpCodes.Ldvirtftn, methodInfo);

--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -503,7 +503,7 @@ namespace HarmonyLib
 									}
 								}
 
-								if (!methodInfo.IsStatic && (harmonyMethod.virtualDelegate ?? true))
+								if (!methodInfo.IsStatic && harmonyMethod.virtualDelegate)
 								{
 									emitter.Emit(OpCodes.Dup);
 									emitter.Emit(OpCodes.Ldvirtftn, methodInfo);

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -61,28 +61,36 @@ namespace HarmonyLib
 		Snapshot
 	}
 
-	/// <summary>Specifies the type of method binding used during a method call (method call dispatching mechanics)</summary>
+	/// <summary>Specifies the type of method call dispatching mechanics</summary>
 	///
-	public enum MethodBinding
+	public enum MethodDispatchType
 	{
-		/// <summary>Call the method using dynamic dispatching like with ordinary virtual/override mechanics</summary>
+		/// <summary>Call the method using dynamic dispatching if method is virtual (including overriden)</summary>
 		/// <remarks>
 		/// <para>
-		/// a.k.a. late binding or dynamic binding, this directly corresponds with the <see cref="System.Reflection.Emit.OpCodes.Callvirt"/> instruction.
+		/// This is the built-in form of late binding (a.k.a. dynamic binding) and is the default dispatching mechanic in C#.
+		/// This directly corresponds with the <see cref="System.Reflection.Emit.OpCodes.Callvirt"/> instruction.
 		/// </para>
 		/// <para>
-		/// For virtual methods (including overriden methods), the instance type's most-derived/overriden implementation of the method is called.
-		/// For non-virtual methods, same behavior as <see cref="Call"/>: the exact specified method implementation is called.
+		/// For virtual (including overriden) methods, the instance type's most-derived/overriden implementation of the method is called.
+		/// For non-virtual (including static) methods, same behavior as <see cref="Call"/>: the exact specified method implementation is called.
+		/// </para>
+		/// <para>
+		/// Note: This is not a fully dynamic dispatch, since non-virtual (including static) methods are still called non-virtually.
+		/// A fully dynamic dispatch in C# involves using
+		/// the <see href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/reference-types#the-dynamic-type"><c>dynamic</c> type</see>
+		/// (actually a fully dynamic binding, since even the name and overload resolution happens at runtime), which <see cref="MethodDispatchType"/> does not support.
 		/// </para>
 		/// </remarks>
-		CallVirtually,
-		/// <summary>Call the specified method only, do not dispatch dynamically</summary>
+		VirtualCall,
+		/// <summary>Call the method using static dispatching, regardless of whether method is virtual (including overriden) or non-virtual (including static)</summary>
 		/// <remarks>
 		/// <para>
-		/// a.k.a. early binding or static binding, this directly corresponds with the <see cref="System.Reflection.Emit.OpCodes.Call"/> instruction.
+		/// a.k.a. non-virtual dispatching, early binding, or static binding.
+		/// This directly corresponds with the <see cref="System.Reflection.Emit.OpCodes.Call"/> instruction.
 		/// </para>
 		/// <para>
-		/// For both virtual and non-virtual methods, the exact specified method implementation is called.
+		/// For both virtual (including overriden) and non-virtual (including static) methods, the exact specified method implementation is called, without virtual/override mechanics.
 		/// </para>
 		/// </remarks>
 		Call
@@ -369,46 +377,46 @@ namespace HarmonyLib
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		///
-		public HarmonyDelegate(Type declaringType, MethodBinding methodBinding)
+		public HarmonyDelegate(Type declaringType, MethodDispatchType methodDispatchType)
 			: base(declaringType, MethodType.Normal)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		///
-		public HarmonyDelegate(Type declaringType, MethodBinding methodBinding, params Type[] argumentTypes)
+		public HarmonyDelegate(Type declaringType, MethodDispatchType methodDispatchType, params Type[] argumentTypes)
 			: base(declaringType, MethodType.Normal, argumentTypes)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		/// <param name="argumentVariations">Array of <see cref="ArgumentType"/></param>
 		///
-		public HarmonyDelegate(Type declaringType, MethodBinding methodBinding, Type[] argumentTypes, ArgumentType[] argumentVariations)
+		public HarmonyDelegate(Type declaringType, MethodDispatchType methodDispatchType, Type[] argumentTypes, ArgumentType[] argumentVariations)
 			: base(declaringType, MethodType.Normal, argumentTypes, argumentVariations)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="declaringType">The declaring class/type</param>
 		/// <param name="methodName">The name of the method, property or constructor to patch</param>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		///
-		public HarmonyDelegate(Type declaringType, string methodName, MethodBinding methodBinding)
+		public HarmonyDelegate(Type declaringType, string methodName, MethodDispatchType methodDispatchType)
 			: base(declaringType, methodName, MethodType.Normal)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -434,41 +442,41 @@ namespace HarmonyLib
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
 		/// <param name="methodName">The name of the method, property or constructor to patch</param>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		///
-		public HarmonyDelegate(string methodName, MethodBinding methodBinding)
+		public HarmonyDelegate(string methodName, MethodDispatchType methodDispatchType)
 			: base(methodName, MethodType.Normal)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies call dispatching mechanics for the delegate</summary>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		///
-		public HarmonyDelegate(MethodBinding methodBinding)
+		public HarmonyDelegate(MethodDispatchType methodDispatchType)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		///
-		public HarmonyDelegate(MethodBinding methodBinding, params Type[] argumentTypes)
+		public HarmonyDelegate(MethodDispatchType methodDispatchType, params Type[] argumentTypes)
 			: base(MethodType.Normal, argumentTypes)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
-		/// <param name="methodBinding">The <see cref="MethodBinding"/></param>
+		/// <param name="methodDispatchType">The <see cref="MethodDispatchType"/></param>
 		/// <param name="argumentTypes">An array of argument types to target overloads</param>
 		/// <param name="argumentVariations">An array of <see cref="ArgumentType"/></param>
 		///
-		public HarmonyDelegate(MethodBinding methodBinding, Type[] argumentTypes, ArgumentType[] argumentVariations)
+		public HarmonyDelegate(MethodDispatchType methodDispatchType, Type[] argumentTypes, ArgumentType[] argumentVariations)
 			: base(MethodType.Normal, argumentTypes, argumentVariations)
 		{
-			info.virtualDelegate = methodBinding == MethodBinding.CallVirtually;
+			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -382,7 +382,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(Type declaringType, MethodDispatchType methodDispatchType)
 			: base(declaringType, MethodType.Normal)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -393,7 +393,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(Type declaringType, MethodDispatchType methodDispatchType, params Type[] argumentTypes)
 			: base(declaringType, MethodType.Normal, argumentTypes)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -405,7 +405,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(Type declaringType, MethodDispatchType methodDispatchType, Type[] argumentTypes, ArgumentType[] argumentVariations)
 			: base(declaringType, MethodType.Normal, argumentTypes, argumentVariations)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -416,7 +416,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(Type declaringType, string methodName, MethodDispatchType methodDispatchType)
 			: base(declaringType, methodName, MethodType.Normal)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -447,7 +447,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(string methodName, MethodDispatchType methodDispatchType)
 			: base(methodName, MethodType.Normal)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies call dispatching mechanics for the delegate</summary>
@@ -455,7 +455,7 @@ namespace HarmonyLib
 		///
 		public HarmonyDelegate(MethodDispatchType methodDispatchType)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -465,7 +465,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(MethodDispatchType methodDispatchType, params Type[] argumentTypes)
 			: base(MethodType.Normal, argumentTypes)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>
@@ -476,7 +476,7 @@ namespace HarmonyLib
 		public HarmonyDelegate(MethodDispatchType methodDispatchType, Type[] argumentTypes, ArgumentType[] argumentVariations)
 			: base(MethodType.Normal, argumentTypes, argumentVariations)
 		{
-			info.virtualDelegate = methodDispatchType == MethodDispatchType.VirtualCall;
+			info.nonVirtualDelegate = methodDispatchType == MethodDispatchType.Call;
 		}
 
 		/// <summary>An annotation that specifies a method, property or constructor to patch</summary>

--- a/Harmony/Public/HarmonyMethod.cs
+++ b/Harmony/Public/HarmonyMethod.cs
@@ -50,9 +50,10 @@ namespace HarmonyLib
 		/// 
 		public bool? debug;
 
-		/// <summary>Use <see cref="MethodDispatchType.VirtualCall"/> mechanics for <see cref="HarmonyDelegate"/>-attributed delegate; defaults to <c>true</c></summary>
+		/// <summary>Whether to use <see cref="MethodDispatchType.Call"/> (<c>true</c>) or <see cref="MethodDispatchType.VirtualCall"/> (<c>false</c>) mechanics
+		/// for <see cref="HarmonyDelegate"/>-attributed delegate</summary>
 		/// 
-		public bool virtualDelegate = true;
+		public bool nonVirtualDelegate;
 
 		/// <summary>Default constructor</summary>
 		/// 

--- a/Harmony/Public/HarmonyMethod.cs
+++ b/Harmony/Public/HarmonyMethod.cs
@@ -50,9 +50,9 @@ namespace HarmonyLib
 		/// 
 		public bool? debug;
 
-		/// <summary>Use inheritance for harmony delegates</summary>
+		/// <summary>Use <see cref="MethodDispatchType.VirtualCall"/> mechanics for <see cref="HarmonyDelegate"/>-attributed delegate; defaults to <c>true</c></summary>
 		/// 
-		public bool? virtualDelegate;
+		public bool virtualDelegate = true;
 
 		/// <summary>Default constructor</summary>
 		/// 

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -946,8 +946,8 @@ namespace HarmonyLib
 		/// instance delegate where the delegate invocation always applies to the given <paramref name="instance"/>.
 		/// </param>
 		/// <param name="virtualCall">
-		/// Only applies for instance methods. If <c>true</c> (default), invocation of the delegate calls the instance method virtually
-		/// (if <paramref name="method"/> is virtual, the instance type's most-derived/overriden implementation of the method is called);
+		/// Only applies for instance methods. If <c>true</c> (default) and <paramref name="method"/> is virtual, invocation of the delegate
+		/// calls the instance method virtually (the instance type's most-derived/overriden implementation of the method is called);
 		/// else, invocation of the delegate calls the exact specified <paramref name="method"/> (this is useful for calling base class methods)
 		/// Note: if <c>false</c> and <paramref name="method"/> is an interface method, an ArgumentException is thrown.
 		/// </param>
@@ -1118,7 +1118,7 @@ namespace HarmonyLib
 			var method = harmonyMethod.GetOriginalMethod() as MethodInfo;
 			if (method == null)
 				throw new NullReferenceException($"Delegate {typeof(DelegateType)} has no defined original method");
-			return MethodDelegate<DelegateType>(method, instance, harmonyMethod.virtualDelegate ?? true);
+			return MethodDelegate<DelegateType>(method, instance, harmonyMethod.virtualDelegate);
 		}
 
 		/// <summary>Returns who called the current method</summary>

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -1118,7 +1118,7 @@ namespace HarmonyLib
 			var method = harmonyMethod.GetOriginalMethod() as MethodInfo;
 			if (method == null)
 				throw new NullReferenceException($"Delegate {typeof(DelegateType)} has no defined original method");
-			return MethodDelegate<DelegateType>(method, instance, harmonyMethod.virtualDelegate);
+			return MethodDelegate<DelegateType>(method, instance, harmonyMethod.nonVirtualDelegate == false);
 		}
 
 		/// <summary>Returns who called the current method</summary>

--- a/HarmonyTests/Patching/Assets/PatchClasses.cs
+++ b/HarmonyTests/Patching/Assets/PatchClasses.cs
@@ -1076,10 +1076,10 @@ namespace HarmonyLibTests.Assets
 	[HarmonyPatch(typeof(InjectDelegateClass), "Method")]
 	public class InjectDelegateClassPatch
 	{
-		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod", MethodBinding.Call)]
+		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod", MethodDispatchType.Call)]
 		public delegate string TestDelegate(ref string s, int n);
 
-		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod", MethodBinding.CallVirtually)]
+		[HarmonyDelegate(typeof(InjectDelegateBaseClass), "SomeMethod", MethodDispatchType.VirtualCall)]
 		public delegate string TestVirtualDelegate(ref string s, int n);
 
 		public static string result = "";


### PR DESCRIPTION
Edited quote from discord:

### `MethodBinding` => `MethodDispatchType`

I'm having second thoughts on the `MethodBinding` naming, since "binding" is an unfortunately overused term, even within delegates, e.g. bound/unbound delegates. And there's also the existing `System.Reflection.Binder` and `System.Runtime.Serialization.SerializationBinder` and `Microsoft.CSharp.RuntimeBinder.Binder` and `System.Runtime.CompilerServices.CallSiteBinder` classes, and that's not even getting into all the "data binding" stuff.

I think "dispatch" as suggested earlier is a better option, since it's far less overloaded of a term. Indeed dynamic dispatch is considered a specific type of dynamic/late binding (although the difference might be academic in C#, excluding Harmony patching; probably only relevant for languages that can add/remove/change methods at runtime). In fact, "virtual dispatch" isn't the only form of "dynamic dispatch" that C# can use - there's also the `dynamic` type, which is basically a fully dynamic binding (name and overload resolution happens at runtime, method doesn't even need to exist at compile-time).

So `MethodBinding` has been renamed to `MethodDispatchType`, and XML docs updated accordingly.

### HarmonyMethod.virtualDelegate defaulting logic

There's no need for `virtualDelegate` to be a `bool?` (nullable bool) like `HarmonyMethod.debug`. The latter is only nullable, because the default value for it can changed via `Harmony.DEBUG`.

So `HarmonyMethod.virtualDelegate` defaulting logic has been moved into `HarmonyMethod` itself, and XML docs updated accordingly (including what is the default value).

### `virtualCall`/`CallVirtually`/`Call` naming

`MethodDispatchType.CallVirtually` is renamed to `MethodDispatchType.VirtualCall` to:
a) align with `AccessTools.MethodDelegate`'s `virtualCall` parameter
b) be a noun with adjective (like most enum value names), rather than a verb with adverb

#### Open questions

1. Should `AccessTools.MethodDelegate` use a `MethodDispatchType` parameter instead of `bool virtualCall` parameter?

2. Should `MethodDispatchType.Call` be renamed to something like `StaticCall`? I know there were concerns with confusion with static methods, but "Call" just by itself is also kind of confusing.