### PR TITLE
Fix exception on patchall when optional dependencies are missing

### DIFF
--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -103,7 +103,17 @@ namespace HarmonyLib
 		/// 
 		public void PatchAll(Assembly assembly)
 		{
-			assembly.GetTypes().Do(type => CreateClassProcessor(type).Patch());
+			Type[] types;
+			try
+			{
+				types = assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException ex)
+			{
+				types = ex.Types.Where(tp => tp != null).ToArray();
+			}
+
+			types.Do(type => CreateClassProcessor(type).Patch());
 		}
 
 		/// <summary>Creates patches by manually specifying the methods</summary>


### PR DESCRIPTION
Exception example:
```
System.Reflection.ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
  at (wrapper managed-to-native) System.Reflection.Assembly.GetTypes(System.Reflection.Assembly,bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <e1319b7195c343e79b385cd3aa43f5dc>:0
  at HarmonyLib.Harmony.PatchAll (System.Reflection.Assembly assembly) [0x00000] in <e1f1ac2cbe0f4a33bf2c833b6962b66e>:0
```