### PR TITLE
AccessTools.*FieldRefAccess improvements, including struct support

### DIFF
--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -133,10 +133,10 @@ namespace HarmonyLib
 					FileLog.Log("AccessTools.DeclaredField: name is null");
 				return null;
 			}
-			var field = type.GetField(name, allDeclared);
-			if (field == null && Harmony.DEBUG)
+			var fieldInfo = type.GetField(name, allDeclared);
+			if (fieldInfo == null && Harmony.DEBUG)
 				FileLog.Log($"AccessTools.DeclaredField: Could not find field for type {type} and name {name}");
-			return field;
+			return fieldInfo;
 		}
 
 		/// <summary>Gets the reflection information for a field by searching the type and all its super types</summary>
@@ -158,10 +158,10 @@ namespace HarmonyLib
 					FileLog.Log("AccessTools.Field: name is null");
 				return null;
 			}
-			var field = FindIncludingBaseTypes(type, t => t.GetField(name, all));
-			if (field == null && Harmony.DEBUG)
+			var fieldInfo = FindIncludingBaseTypes(type, t => t.GetField(name, all));
+			if (fieldInfo == null && Harmony.DEBUG)
 				FileLog.Log($"AccessTools.Field: Could not find field for type {type} and name {name}");
-			return field;
+			return fieldInfo;
 		}
 
 		/// <summary>Gets the reflection information for a field</summary>
@@ -177,10 +177,10 @@ namespace HarmonyLib
 					FileLog.Log("AccessTools.DeclaredField: type is null");
 				return null;
 			}
-			var field = GetDeclaredFields(type).ElementAtOrDefault(idx);
-			if (field == null && Harmony.DEBUG)
+			var fieldInfo = GetDeclaredFields(type).ElementAtOrDefault(idx);
+			if (fieldInfo == null && Harmony.DEBUG)
 				FileLog.Log($"AccessTools.DeclaredField: Could not find field for type {type} and idx {idx}");
-			return field;
+			return fieldInfo;
 		}
 
 		/// <summary>Gets the reflection information for a directly declared property</summary>
@@ -345,10 +345,9 @@ namespace HarmonyLib
 				catch (AmbiguousMatchException ex)
 				{
 					result = FindIncludingBaseTypes(type, t => t.GetMethod(name, all, null, new Type[0], modifiers));
-
 					if (result == null)
 					{
-						throw new AmbiguousMatchException($"Ambiguous match in Harmony patch for {type}:{name}." + ex);
+						throw new AmbiguousMatchException($"Ambiguous match in Harmony patch for {type}:{name}", ex);
 					}
 				}
 			}

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -73,44 +73,43 @@ namespace HarmonyLib
 			}
 		}
 
-		/// <summary>Applies a function going up the type hierarchy and stops at the first non null result</summary>
+		/// <summary>Applies a function going up the type hierarchy and stops at the first non-<c>null</c> result</summary>
 		/// <typeparam name="T">Result type of func()</typeparam>
 		/// <param name="type">The class/type to start with</param>
 		/// <param name="func">The evaluation function returning T</param>
-		/// <returns>Returns the first non null result or <c>default(T)</c> when reaching the top level type object</returns>
+		/// <returns>The first non-<c>null</c> result, or <c>null</c> if no match</returns>
+		/// <remarks>
+		/// The type hierarchy of a class or value type (including struct) does NOT include implemented interfaces,
+		/// and the type hierarchy of an interface is only itself (regardless of whether that interface implements other interfaces).
+		/// The top-most type in the type hierarchy of all non-interface types (including value types) is <see cref="object"/>.
+		/// </remarks>
 		///
 		public static T FindIncludingBaseTypes<T>(Type type, Func<Type, T> func) where T : class
 		{
 			while (true)
 			{
 				var result = func(type);
-#pragma warning disable RECS0017
 				if (result != null) return result;
-#pragma warning restore RECS0017
-				if (type == typeof(object)) return default;
 				type = type.BaseType;
+				if (type is null) return null;
 			}
 		}
 
-		/// <summary>Applies a function going into inner types and stops at the first non null result</summary>
+		/// <summary>Applies a function going into inner types and stops at the first non-<c>null</c> result</summary>
 		/// <typeparam name="T">Generic type parameter</typeparam>
 		/// <param name="type">The class/type to start with</param>
 		/// <param name="func">The evaluation function returning T</param>
-		/// <returns>Returns the first non null result or null with no match</returns>
+		/// <returns>The first non-<c>null</c> result, or <c>null</c> if no match</returns>
 		///
 		public static T FindIncludingInnerTypes<T>(Type type, Func<Type, T> func) where T : class
 		{
 			var result = func(type);
-#pragma warning disable RECS0017
 			if (result != null) return result;
-#pragma warning restore RECS0017
 			foreach (var subType in type.GetNestedTypes(all))
 			{
 				result = FindIncludingInnerTypes(subType, func);
-#pragma warning disable RECS0017
 				if (result != null)
 					break;
-#pragma warning restore RECS0017
 			}
 			return result;
 		}

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -802,7 +802,7 @@ namespace HarmonyLib
 		/// <para>
 		/// This delegate cannot be used for instance fields of structs, since a struct instance passed to the delegate would be passed by
 		/// value and thus would be a copy that only exists within the delegate's invocation. This is fine for a readonly reference,
-		/// but makes assigning to the reference an exercise in futility. Use <see cref="StructFieldRef{T, F}"/> instead.
+		/// but makes assignment futile. Use <see cref="StructFieldRef{T, F}"/> instead.
 		/// </para>
 		/// <para>
 		/// Note that <typeparamref name="T"/> is not required to be the field's declaring type. It can be a parent class (including <see cref="object"/>),
@@ -861,6 +861,13 @@ namespace HarmonyLib
 		/// <param name="instance">The instance</param>
 		/// <param name="fieldName">The name of the field</param>
 		/// <returns>A readable/assignable reference to the field</returns>
+		/// <remarks>
+		/// <para>
+		/// This method is meant for one-off access to a field's value for a single instance.
+		/// If you need to access a field's value for potentially multiple instances, use <see cref="FieldRefAccess{T, F}(string)"/> instead.
+		/// <c>FieldRefAccess&lt;T, F&gt;(instance, fieldName)</c> is functionally equivalent to <c>FieldRefAccess&lt;T, F&gt;(fieldName)(instance)</c>.
+		/// </para>
+		/// </remarks>
 		///
 		public static ref F FieldRefAccess<T, F>(T instance, string fieldName) where T : class
 		{
@@ -892,8 +899,14 @@ namespace HarmonyLib
 		/// (for static fields, the <c>instance</c> delegate parameter is ignored)
 		/// </returns>
 		/// <remarks>
+		/// <para>
+		/// This method is meant for cases where the given type is only known at runtime and thus can't be used as a type parameter <c>T</c>
+		/// in e.g. <see cref="FieldRefAccess{T, F}(string)"/>.
+		/// </para>
+		/// <para>
 		/// This method supports static fields, even those defined in structs, for legacy reasons.
 		/// Consider using <see cref="StaticFieldRefAccess{F}(Type, string)"/> (and other overloads) instead for static fields.
+		/// </para>
 		/// </remarks>
 		///
 		public static FieldRef<object, F> FieldRefAccess<F>(Type type, string fieldName)
@@ -936,6 +949,10 @@ namespace HarmonyLib
 		/// <param name="fieldInfo">The field</param>
 		/// <returns>A readable/assignable <see cref="FieldRef{T,F}"/> delegate</returns>
 		/// <remarks>
+		/// <para>
+		/// This method is meant for cases where the field has already been obtained, avoiding the field searching cost in
+		/// e.g. <see cref="FieldRefAccess{T, F}(string)"/>.
+		/// </para>
 		/// <para>
 		/// This method supports static fields, even those defined in structs, for legacy reasons.
 		/// For such static fields, <typeparamref name="T"/> is effectively ignored.
@@ -980,6 +997,13 @@ namespace HarmonyLib
 		/// <param name="instance">The instance</param>
 		/// <param name="fieldInfo">The field</param>
 		/// <returns>A readable/assignable reference to the field</returns>
+		/// <remarks>
+		/// <para>
+		/// This method is meant for one-off access to a field's value for a single instance and where the field has already been obtained.
+		/// If you need to access a field's value for potentially multiple instances, use <see cref="FieldRefAccess{T, F}(FieldInfo)"/> instead.
+		/// <c>FieldRefAccess&lt;T, F&gt;(instance, fieldInfo)</c> is functionally equivalent to <c>FieldRefAccess&lt;T, F&gt;(fieldInfo)(instance)</c>.
+		/// </para>
+		/// </remarks>
 		///
 		public static ref F FieldRefAccess<T, F>(T instance, FieldInfo fieldInfo) where T : class
 		{
@@ -1006,19 +1030,6 @@ namespace HarmonyLib
 			{
 				throw new ArgumentException($"FieldRefAccess<{typeof(T)}, {typeof(F)}> for {instance}, {fieldInfo} caused an exception", ex);
 			}
-		}
-
-		static bool FieldRefNeedsClasscast(Type delegateInstanceType, Type declaringType)
-		{
-			var needCastclass = false;
-			if (delegateInstanceType != declaringType)
-			{
-				needCastclass = delegateInstanceType.IsAssignableFrom(declaringType);
-				if (needCastclass is false && declaringType.IsAssignableFrom(delegateInstanceType) is false)
-					throw new ArgumentException("FieldDeclaringType must be assignable from or to T (FieldRefAccess instance type) - " +
-						"\"instanceOfT is FieldDeclaringType\" must be possible");
-			}
-			return needCastclass;
 		}
 
 		static FieldRef<T, F> FieldRefAccessInternal<T, F>(FieldInfo fieldInfo, bool needCastclass) where T : class
@@ -1096,6 +1107,13 @@ namespace HarmonyLib
 		/// <param name="instance">The instance</param>
 		/// <param name="fieldName">The name of the field</param>
 		/// <returns>A readable/assignable reference to the field</returns>
+		/// <remarks>
+		/// <para>
+		/// This method is meant for one-off access to a field's value for a single instance.
+		/// If you need to access a field's value for potentially multiple instances, use <see cref="StructFieldRefAccess{T, F}(string)"/> instead.
+		/// <c>StructFieldRefAccess&lt;T, F&gt;(ref instance, fieldName)</c> is functionally equivalent to <c>StructFieldRefAccess&lt;T, F&gt;(fieldName)(ref instance)</c>.
+		/// </para>
+		/// </remarks>
 		///
 		public static ref F StructFieldRefAccess<T, F>(ref T instance, string fieldName) where T : struct
 		{
@@ -1119,6 +1137,13 @@ namespace HarmonyLib
 		/// </typeparam>
 		/// <param name="fieldInfo">The field</param>
 		/// <returns>A readable/assignable <see cref="StructFieldRef{T,F}"/> delegate</returns>
+		/// <remarks>
+		/// <para>
+		/// This method is meant for cases where the field has already been obtained, avoiding the field searching cost in
+		/// e.g. <see cref="StructFieldRefAccess{T, F}(string)"/>.
+		/// </para>
+		/// </remarks>
+		///
 		public static StructFieldRef<T, F> StructFieldRefAccess<T, F>(FieldInfo fieldInfo) where T : struct
 		{
 			if (fieldInfo is null)
@@ -1143,6 +1168,13 @@ namespace HarmonyLib
 		/// <param name="instance">The instance</param>
 		/// <param name="fieldInfo">The field</param>
 		/// <returns>A readable/assignable reference to the field</returns>
+		/// <remarks>
+		/// <para>
+		/// This method is meant for one-off access to a field's value for a single instance and where the field has already been obtained.
+		/// If you need to access a field's value for potentially multiple instances, use <see cref="StructFieldRefAccess{T, F}(FieldInfo)"/> instead.
+		/// <c>StructFieldRefAccess&lt;T, F&gt;(ref instance, fieldInfo)</c> is functionally equivalent to <c>StructFieldRefAccess&lt;T, F&gt;(fieldInfo)(ref instance)</c>.
+		/// </para>
+		/// </remarks>
 		///
 		public static ref F StructFieldRefAccess<T, F>(ref T instance, FieldInfo fieldInfo) where T : struct
 		{
@@ -1159,14 +1191,6 @@ namespace HarmonyLib
 			}
 		}
 
-		static void ValidateStructField<T, F>(FieldInfo fieldInfo) where T : struct
-		{
-			if (fieldInfo.IsStatic)
-				throw new ArgumentException("Field must not be static");
-			if (fieldInfo.DeclaringType != typeof(T))
-				throw new ArgumentException("FieldDeclaringType must be T (StructFieldRefAccess instance type)");
-		}
-
 		static StructFieldRef<T, F> StructFieldRefAccessInternal<T, F>(FieldInfo fieldInfo) where T : struct
 		{
 			ValidateFieldType<F>(fieldInfo);
@@ -1180,16 +1204,6 @@ namespace HarmonyLib
 			il.Emit(OpCodes.Ret);
 
 			return (StructFieldRef<T, F>)dm.Generate().CreateDelegate(typeof(StructFieldRef<T, F>));
-		}
-
-		static FieldInfo GetInstanceField(Type type, string fieldName)
-		{
-			var fieldInfo = Field(type, fieldName);
-			if (fieldInfo is null)
-				throw new MissingFieldException(type.Name, fieldName);
-			if (fieldInfo.IsStatic)
-				throw new ArgumentException("Field must not be static");
-			return fieldInfo;
 		}
 
 		/// <summary>A readable/assignable reference delegate to a static field</summary>
@@ -1302,6 +1316,37 @@ namespace HarmonyLib
 			il.Emit(OpCodes.Ret);
 
 			return (FieldRef<F>)dm.Generate().CreateDelegate(typeof(FieldRef<F>));
+		}
+
+		static FieldInfo GetInstanceField(Type type, string fieldName)
+		{
+			var fieldInfo = Field(type, fieldName);
+			if (fieldInfo is null)
+				throw new MissingFieldException(type.Name, fieldName);
+			if (fieldInfo.IsStatic)
+				throw new ArgumentException("Field must not be static");
+			return fieldInfo;
+		}
+
+		static bool FieldRefNeedsClasscast(Type delegateInstanceType, Type declaringType)
+		{
+			var needCastclass = false;
+			if (delegateInstanceType != declaringType)
+			{
+				needCastclass = delegateInstanceType.IsAssignableFrom(declaringType);
+				if (needCastclass is false && declaringType.IsAssignableFrom(delegateInstanceType) is false)
+					throw new ArgumentException("FieldDeclaringType must be assignable from or to T (FieldRefAccess instance type) - " +
+						"\"instanceOfT is FieldDeclaringType\" must be possible");
+			}
+			return needCastclass;
+		}
+
+		static void ValidateStructField<T, F>(FieldInfo fieldInfo) where T : struct
+		{
+			if (fieldInfo.IsStatic)
+				throw new ArgumentException("Field must not be static");
+			if (fieldInfo.DeclaringType != typeof(T))
+				throw new ArgumentException("FieldDeclaringType must be T (StructFieldRefAccess instance type)");
 		}
 
 		static void ValidateFieldType<F>(FieldInfo fieldInfo)

--- a/HarmonyTests/Tools/Assets/AccessToolsClass.cs
+++ b/HarmonyTests/Tools/Assets/AccessToolsClass.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using HarmonyLib;
 
 namespace HarmonyLibTests.Assets
@@ -11,11 +12,39 @@ namespace HarmonyLibTests.Assets
 		string Method1();
 	}
 
+	public interface IInner { }
+
 #pragma warning disable CS0169, CS0414, IDE0044, IDE0051, IDE0052
 	public class AccessToolsClass : IAccessToolsType
 	{
-		class Inner
+		private class Inner : IInner
 		{
+			public int x;
+
+			public override string ToString()
+			{
+				return x.ToString();
+			}
+		}
+
+		public static IInner NewInner(int x)
+		{
+			return new Inner { x = x };
+		}
+
+		private struct InnerStruct : IInner
+		{
+			public int x;
+
+			public override string ToString()
+			{
+				return x.ToString();
+			}
+		}
+
+		public static IInner NewInnerStruct(int x)
+		{
+			return new InnerStruct { x = x };
 		}
 
 		protected string field1 = "field1orig";
@@ -25,6 +54,10 @@ namespace HarmonyLibTests.Assets
 		// https://docs.microsoft.com/en-us/dotnet/core/compatibility/corefx#fieldinfosetvalue-throws-exception-for-static-init-only-fields
 		// As of .NET Core 3.1, the FieldRef delegates can change static readonly fields, so all resetting happens in the unit tests themselves.
 		private static readonly string field4 = "field4orig";
+		private Inner field5 = new Inner { x = 999 };
+		private Inner[] field6 = new Inner[] { new Inner { x = 11 }, new Inner { x = 22 } };
+		private InnerStruct field7 = new InnerStruct { x = 999 };
+		private List<InnerStruct> field8 = new List<InnerStruct> { new InnerStruct { x = 11 }, new InnerStruct { x = 22 } };
 
 		private int _property = 314159;
 

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -192,7 +192,7 @@ namespace HarmonyLibTests
 			Assert.Null(AccessTools.DeclaredField(structType, "unknown"));
 
 			var interfaceType = typeof(IAccessToolsType);
-			Assert.Throws(typeof(NullReferenceException), () => AccessTools.Field(interfaceType, "unknown")); // TODO: should return null, not throw NRE
+			Assert.Null(AccessTools.Field(interfaceType, "unknown"));
 			Assert.Null(AccessTools.DeclaredField(interfaceType, "unknown"));
 		}
 
@@ -236,7 +236,7 @@ namespace HarmonyLibTests
 			var interfaceType = typeof(IAccessToolsType);
 			Assert.NotNull(AccessTools.Property(interfaceType, "Property1"));
 			Assert.NotNull(AccessTools.DeclaredProperty(interfaceType, "Property1"));
-			Assert.Throws(typeof(NullReferenceException), () => AccessTools.Property(interfaceType, "unknown")); // TODO: should return null, not throw NRE
+			Assert.Null(AccessTools.Property(interfaceType, "unknown"));
 			Assert.Null(AccessTools.DeclaredProperty(interfaceType, "unknown"));
 		}
 
@@ -311,7 +311,7 @@ namespace HarmonyLibTests
 			var interfaceType = typeof(IAccessToolsType);
 			Assert.NotNull(AccessTools.Method(interfaceType, "Method1"));
 			Assert.NotNull(AccessTools.DeclaredMethod(interfaceType, "Method1"));
-			Assert.Throws(typeof(NullReferenceException), () => AccessTools.Method(interfaceType, "unknown")); // TODO: should return null, not throw NRE
+			Assert.Null(AccessTools.Method(interfaceType, "unknown"));
 			Assert.Null(AccessTools.DeclaredMethod(interfaceType, "unknown"));
 		}
 

--- a/HarmonyTests/Tools/TestFieldRefAccess.cs
+++ b/HarmonyTests/Tools/TestFieldRefAccess.cs
@@ -416,15 +416,12 @@ namespace HarmonyLibTests
 			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
 		}
 
-		// TODO: This shouldn't exist - AccessTools.Field/FindIncludingBaseTypes should be fixed to not NRE on interfaces,
-		// and FieldRefAccess's T=object special-casing should be generalized to handle any type assignable from field's declaring type.
+		// TODO: This shouldn't exist - FieldRefAccess's T=object special-casing should be generalized to handle any type assignable from field's declaring type.
 		// Only FieldMissingOnTypeT should be used when T is an interface type.
 		static Dictionary<string, ReusableConstraint> InterfaceT(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
 		{
 			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				["FieldRefAccess<F>(typeof(T), fieldName)(instance)"] = Throws.TypeOf<NullReferenceException>(),
-				["FieldRefAccess<F>(typeof(T), fieldName)()"] = Throws.TypeOf<NullReferenceException>(),
 				["FieldRefAccess<T, F>(field)(instance)"] = Throws.Exception,
 				["FieldRefAccess<T, F>(field)()"] = Throws.Exception,
 			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));

--- a/HarmonyTests/Tools/TestFieldRefAccess.cs
+++ b/HarmonyTests/Tools/TestFieldRefAccess.cs
@@ -57,31 +57,30 @@ namespace HarmonyLibTests
 			}
 		}
 
-		// TODO: AccessTools.StructFieldRefAccess
-		//static IATestCase<T, F> ATestCase<T, F>(AccessTools.StructFieldRef<T, F> fieldRef) where T : struct
-		//{
-		//	return new StructFieldRefTestCase<T, F>(fieldRef);
-		//}
+		static IATestCase<T, F> ATestCase<T, F>(AccessTools.StructFieldRef<T, F> fieldRef) where T : struct
+		{
+			return new StructFieldRefTestCase<T, F>(fieldRef);
+		}
 
-		//class StructFieldRefTestCase<T, F> : IATestCase<T, F> where T : struct
-		//{
-		//	readonly AccessTools.StructFieldRef<T, F> fieldRef;
+		class StructFieldRefTestCase<T, F> : IATestCase<T, F> where T : struct
+		{
+			readonly AccessTools.StructFieldRef<T, F> fieldRef;
 
-		//	public StructFieldRefTestCase(AccessTools.StructFieldRef<T, F> fieldRef)
-		//	{
-		//		this.fieldRef = fieldRef;
-		//	}
+			public StructFieldRefTestCase(AccessTools.StructFieldRef<T, F> fieldRef)
+			{
+				this.fieldRef = fieldRef;
+			}
 
-		//	public F Get(ref T instance)
-		//	{
-		//		return fieldRef(ref instance);
-		//	}
+			public F Get(ref T instance)
+			{
+				return fieldRef(ref instance);
+			}
 
-		//	public void Set(ref T instance, F value)
-		//	{
-		//		fieldRef(ref instance) = value;
-		//	}
-		//}
+			public void Set(ref T instance, F value)
+			{
+				fieldRef(ref instance) = value;
+			}
+		}
 
 		// AccessTools.StaticFieldRefAccess
 		static IATestCase<T, F> ATestCase<T, F>(AccessTools.FieldRef<F> fieldRef)
@@ -240,14 +239,6 @@ namespace HarmonyLibTests
 						var value = testCase.Get(ref instance);
 						// The ?.ToString() is a trick to ensure that value is fully evaluated from the ref value.
 						_ = value?.ToString();
-						// If the constraint is just Throws.Exception (rather than Throws.InstanceOf<ArgumentException), it means we expect potentially
-						// undefined behavior. Depending on the environment, sometimes an exception (typically an InvalidProgramException) is thrown,
-						// while sometimes an exception isn't thrown but the test case's get/set doesn't work correctly. In the latter case we can try
-						// validating that value from the test case's get value matches the value from reflection GetValue.
-						// TODO: Fix FieldRefAccess exception handling to always throw ArgumentException (or InvalidCastException when calling FieldRef
-						// delegate with an incompatible instance) instead and remove this testing hack.
-						if (TestTools.ThrowsConstraintExceptionType(resolvedConstraint) == typeof(Exception) && !Equals(origValue, value))
-							throw new Exception("expected !Equals(origValue, value) (indicates invalid value)");
 						testCase.Set(ref instance, value);
 					}, expectedConstraint, testCaseLabel);
 				}
@@ -305,44 +296,29 @@ namespace HarmonyLibTests
 			{
 				["FieldRefAccess<T, F>(field)(instance)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(field)(instance)),
 				["FieldRefAccess<T, F>(field)()"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(field)()),
-				//["FieldRefAccess<T, F>(instance, field)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(instance, field)), // TODO: implement this overload
+				["FieldRefAccess<T, F>(instance, field)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(instance, field)),
 			};
 		}
 
-		// TODO: Once generic class constraint is added to most FieldRefAccess methods, remove the calls that are no longer compilable.
 		static Dictionary<string, IATestCase<T, F>> AvailableTestCases_FieldRefAccess_Struct_ByName<T, F>(
 			string fieldName) where T : struct
 		{
 			return new Dictionary<string, IATestCase<T, F>>
 			{
-				["FieldRefAccess<T, F>(fieldName)(instance)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(fieldName)(instance)),
-				["FieldRefAccess<T, F>(instance, fieldName)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(instance, fieldName)),
 				["FieldRefAccess<F>(typeof(T), fieldName)(instance)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<F>(typeof(T), fieldName)(instance)),
 				["FieldRefAccess<F>(typeof(T), fieldName)()"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<F>(typeof(T), fieldName)()),
 			};
 		}
 
-		// TODO: Once generic class constraint is added to most FieldRefAccess methods, remove the calls that are no longer compilable.
-		static Dictionary<string, IATestCase<T, F>> AvailableTestCases_FieldRefAccess_Struct_ByFieldInfo<T, F>(
-			FieldInfo field) where T : struct
-		{
-			return new Dictionary<string, IATestCase<T, F>>
-			{
-				["FieldRefAccess<T, F>(field)(instance)"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(field)(instance)),
-				["FieldRefAccess<T, F>(field)()"] = ATestCase<T, F>(instance => ref AccessTools.FieldRefAccess<T, F>(field)()),
-			};
-		}
-
-		// TODO: StructFieldRefAccess
 		static Dictionary<string, IATestCase<T, F>> AvailableTestCases_StructFieldRefAccess<T, F>(FieldInfo field,
 			string fieldName) where T : struct
 		{
 			return new Dictionary<string, IATestCase<T, F>>
 			{
-				//["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(fieldName)(ref instance)),
-				//["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(ref instance, fieldName)),
-				//["StructFieldRefAccess<T, F>(field)(ref instance)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(field)(ref instance)),
-				//["StructFieldRefAccess<T, F>(ref instance, field)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(ref instance, field)),
+				["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(fieldName)(ref instance)),
+				["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(ref instance, fieldName)),
+				["StructFieldRefAccess<T, F>(field)(ref instance)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(field)(ref instance)),
+				["StructFieldRefAccess<T, F>(ref instance, field)"] = ATestCase((ref T instance) => ref AccessTools.StructFieldRefAccess<T, F>(ref instance, field)),
 			};
 		}
 
@@ -383,7 +359,6 @@ namespace HarmonyLibTests
 			var availableTestCases = Merge(
 				AvailableTestCases_StructFieldRefAccess<T, F>(field, field.Name),
 				AvailableTestCases_FieldRefAccess_Struct_ByName<T, F>(field.Name),
-				AvailableTestCases_FieldRefAccess_Struct_ByFieldInfo<T, F>(field),
 				AvailableTestCases_StaticFieldRefAccess_ByName<T, F>(field.Name),
 				AvailableTestCases_StaticFieldRefAccess_ByFieldInfo<T, F>(field));
 			new ATestSuite<T, F>(typeof(T), field, testValue, expectedCaseToConstraint, availableTestCases).Run();
@@ -404,36 +379,12 @@ namespace HarmonyLibTests
 			return newExpectedCaseToConstraint;
 		}
 
-		// TODO: This shouldn't exist - public fields should be treated equivalently as private fields.
-		static Dictionary<string, ReusableConstraint> PublicField(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
-		{
-			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
-			{
-				["FieldRefAccess<T, F>(fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(),
-				["FieldRefAccess<T, F>(instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				["StaticFieldRefAccess<T, F>(fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				["StaticFieldRefAccess<F>(typeof(T), fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
-		}
-
-		// TODO: This shouldn't exist - FieldRefAccess's T=object special-casing should be generalized to handle any type assignable from field's declaring type.
-		// Only FieldMissingOnTypeT should be used when T is an interface type.
-		static Dictionary<string, ReusableConstraint> InterfaceT(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
-		{
-			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
-			{
-				["FieldRefAccess<T, F>(field)(instance)"] = Throws.Exception,
-				["FieldRefAccess<T, F>(field)()"] = Throws.Exception,
-			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
-		}
-
 		static Dictionary<string, ReusableConstraint> FieldMissingOnTypeT(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
 		{
 			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				// TODO: StructFieldRefAccess
-				//["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
-				//["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
+				["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
 				["FieldRefAccess<T, F>(fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(),
 				["FieldRefAccess<T, F>(instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
 				["FieldRefAccess<F>(typeof(T), fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(),
@@ -447,14 +398,21 @@ namespace HarmonyLibTests
 		{
 			// Given that type T must be assignable from instance type, and that instance type is incompatible with field's declaring type,
 			// assume that the field cannot be found on type T.
-			return FieldMissingOnTypeT(expectedCaseToConstraint).Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
+			var newExpectedCaseToConstraint = FieldMissingOnTypeT(expectedCaseToConstraint).Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				// TODO: StructFieldRefAccess
-				//["StructFieldRefAccess<T, F>(field)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
-				//["StructFieldRefAccess<T, F>(ref instance, field)"] = Throws.InstanceOf<ArgumentException>(),
-				["FieldRefAccess<T, F>(field)(instance)"] = SkipTest("incompatible instance type can cause crash"), // TODO: should be InvalidCastException if not already another Throws constraint
-				//["FieldRefAccess<T, F>(instance, field)"] = Throws.InstanceOf<ArgumentException>(), // TODO: implement this overload
+				["StructFieldRefAccess<T, F>(field)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["StructFieldRefAccess<T, F>(ref instance, field)"] = Throws.InstanceOf<ArgumentException>(),
+				["FieldRefAccess<T, F>(instance, field)"] = Throws.InstanceOf<ArgumentException>(),
 			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
+			// Only override Throws.Nothing constraint with InvalidCastException for these test cases,
+			// since other Throws constraints should have precedence over InvalidCastException:
+			// - ArgumentException is only thrown from FieldRefAccess
+			// - NullReferenceException is only thrown when invoking FieldRefAccess-returned delegate with null instance
+			// - InvalidCastException is only thrown when invoking FieldRefAccess-returned delegate with an instance of incompatible type
+			return newExpectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
+			{
+				["FieldRefAccess<T, F>(field)(instance)"] = Throws.TypeOf<InvalidCastException>(),
+			}).Where(pair => expectedCaseToConstraint.TryGetValue(pair.Key, out var constraint) && constraint.Resolve() is ThrowsNothingConstraint));
 		}
 
 		static Dictionary<string, ReusableConstraint> IncompatibleTypeT(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
@@ -464,45 +422,8 @@ namespace HarmonyLibTests
 			// Also assume that the field cannot be found on type T (already assumed in IncompatibleInstanceType).
 			return IncompatibleInstanceType(expectedCaseToConstraint).Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				["FieldRefAccess<T, F>(field)(instance)"] = Throws.Exception, // TODO: should be ArgumentException
-				["FieldRefAccess<T, F>(field)()"] = Throws.Exception, // TODO: should be ArgumentException
-			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
-		}
-
-		// TODO: This shouldn't exist - FieldRefAccess should ignore T for static fields.
-		static Dictionary<string, ReusableConstraint> StaticIncompatibleTypeT(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
-		{
-			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
-			{
-				["FieldRefAccess<T, F>(field)(instance)"] = Throws.Exception,
-				["FieldRefAccess<T, F>(field)()"] = Throws.Exception,
-			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
-		}
-
-		// TODO: This shouldn't exist - FieldRefAccess should be using AccessTools.Field for field search.
-		// For static and non-protected / public / internal-and-same-assembly instance fields declared in parent classes.
-		static Dictionary<string, ReusableConstraint> FieldNotInheritedBySubClass(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
-		{
-			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
-			{
-				// Following search for only declared fields (excludes all fields from parents).
-				["FieldRefAccess<T, F>(fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(),
-				["FieldRefAccess<T, F>(instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				["StaticFieldRefAccess<T, F>(fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				["StaticFieldRefAccess<F>(typeof(T), fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
-		}
-
-		// TODO: This shouldn't exist - FieldRefAccess should be using AccessTools.Field for field search.
-		// For public / protected / internal-and-same-assembly instance fields declared in parent classes.
-		static Dictionary<string, ReusableConstraint> FieldInheritedBySubClass(Dictionary<string, ReusableConstraint> expectedCaseToConstraint)
-		{
-			return expectedCaseToConstraint.Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
-			{
-				// Following search for only declared fields (excludes all fields from parents).
-				// This doesn't include StaticFieldRefAccess since FieldNotInheritedBySubClass should always be used instead for such fields.
-				["FieldRefAccess<T, F>(fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(),
-				["FieldRefAccess<T, F>(instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
+				["FieldRefAccess<T, F>(field)(instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["FieldRefAccess<T, F>(field)()"] = Throws.InstanceOf<ArgumentException>(),
 			}).Where(pair => expectedCaseToConstraint.ContainsKey(pair.Key)));
 		}
 
@@ -517,11 +438,7 @@ namespace HarmonyLibTests
 					continue;
 				var expectedExceptionType = TestTools.ThrowsConstraintExceptionType(expectedConstraint);
 				if (expectedExceptionType is null || expectedExceptionType == typeof(NullReferenceException))
-				{
-					// TODO: StaticFieldRefAccess should throw ArgumentException just like FieldRefAccess.
-					newExpectedCaseToConstraint[testCaseName] = new ReusableConstraint(Throws.InstanceOf(
-						testCaseName.StartsWith("StaticFieldRefAccess") ? typeof(IncompatibleFieldTypeException) : typeof(ArgumentException)));
-				}
+					newExpectedCaseToConstraint[testCaseName] = new ReusableConstraint(Throws.InstanceOf<ArgumentException>());
 			}
 			return newExpectedCaseToConstraint;
 		}
@@ -535,11 +452,11 @@ namespace HarmonyLibTests
 				["FieldRefAccess<F>(typeof(T), fieldName)()"] = Throws.TypeOf<NullReferenceException>(),
 				["FieldRefAccess<T, F>(field)(instance)"] = Throws.Nothing,
 				["FieldRefAccess<T, F>(field)()"] = Throws.TypeOf<NullReferenceException>(),
-				//["FieldRefAccess<T, F>(instance, field)"] = Throws.Nothing, // TODO: implement this overload
+				["FieldRefAccess<T, F>(instance, field)"] = Throws.Nothing,
 				["StaticFieldRefAccess<T, F>(fieldName)"] = Throws.InstanceOf<ArgumentException>(),
 				["StaticFieldRefAccess<F>(typeof(T), fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				["StaticFieldRefAccess<F>(field)()"] = Throws.Exception, // TODO: should be ArgumentException
-				["StaticFieldRefAccess<T, F>(field)"] = Throws.Exception, // TODO: should be ArgumentException
+				["StaticFieldRefAccess<F>(field)()"] = Throws.InstanceOf<ArgumentException>(),
+				["StaticFieldRefAccess<T, F>(field)"] = Throws.InstanceOf<ArgumentException>(),
 			});
 
 		static readonly Dictionary<string, ReusableConstraint> expectedCaseToConstraint_ClassStatic =
@@ -551,7 +468,7 @@ namespace HarmonyLibTests
 				["FieldRefAccess<F>(typeof(T), fieldName)()"] = Throws.Nothing,
 				["FieldRefAccess<T, F>(field)(instance)"] = Throws.Nothing, // T is ignored
 				["FieldRefAccess<T, F>(field)()"] = Throws.Nothing, // T is ignored
-				//["FieldRefAccess<T, F>(instance, field)"] = Throws.InstanceOf<ArgumentException>(), // TODO: implement this overload
+				["FieldRefAccess<T, F>(instance, field)"] = Throws.InstanceOf<ArgumentException>(),
 				["StaticFieldRefAccess<T, F>(fieldName)"] = Throws.Nothing,
 				["StaticFieldRefAccess<F>(typeof(T), fieldName)"] = Throws.Nothing,
 				["StaticFieldRefAccess<F>(field)()"] = Throws.Nothing,
@@ -561,41 +478,27 @@ namespace HarmonyLibTests
 		static readonly Dictionary<string, ReusableConstraint> expectedCaseToConstraint_StructInstance =
 			ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				// TODO: StructFieldRefAccess
-				//["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = Throws.Nothing,
-				//["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = Throws.Nothing,
-				//["StructFieldRefAccess<T, F>(field)(ref instance)"] = Throws.Nothing,
-				//["StructFieldRefAccess<T, F>(ref instance, field)"] = Throws.Nothing,
-				["FieldRefAccess<T, F>(fieldName)(instance)"] = SkipTest("struct instance can cause crash"), // TODO: will be non-compilable due to class constraint
-				["FieldRefAccess<T, F>(instance, fieldName)"] = SkipTest("struct instance can cause crash"), // TODO: will be non-compilable due to class constraint
-				["FieldRefAccess<F>(typeof(T), fieldName)(instance)"] = SkipTest("struct instance can cause crash"), // TODO: should be ArgumentException
-				["FieldRefAccess<F>(typeof(T), fieldName)()"] = Throws.TypeOf<NullReferenceException>(), // TODO: should be ArgumentException
-				["FieldRefAccess<T, F>(field)(instance)"] = SkipTest("struct instance can cause crash"), // TODO: will be non-compilable due to class constraint
-				["FieldRefAccess<T, F>(field)()"] = SkipTest("struct instance can cause crash"), // TODO: will be non-compilable due to class constraint
+				["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = Throws.Nothing,
+				["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = Throws.Nothing,
+				["StructFieldRefAccess<T, F>(field)(ref instance)"] = Throws.Nothing,
+				["StructFieldRefAccess<T, F>(ref instance, field)"] = Throws.Nothing,
+				["FieldRefAccess<F>(typeof(T), fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["FieldRefAccess<F>(typeof(T), fieldName)()"] = Throws.InstanceOf<ArgumentException>(),
 				["StaticFieldRefAccess<T, F>(fieldName)"] = Throws.InstanceOf<ArgumentException>(),
 				["StaticFieldRefAccess<F>(typeof(T), fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				["StaticFieldRefAccess<F>(field)()"] = SkipTest("struct instance can cause crash"), // TODO: should be ArgumentException
-				["StaticFieldRefAccess<T, F>(field)"] = SkipTest("struct instance can cause crash"), // TODO: should be ArgumentException
+				["StaticFieldRefAccess<F>(field)()"] = Throws.InstanceOf<ArgumentException>(),
+				["StaticFieldRefAccess<T, F>(field)"] = Throws.InstanceOf<ArgumentException>(),
 			});
-
-		// TODO: This shouldn't need to exist.
-		static IResolveConstraint MonoThrowsException => AccessTools.IsMonoRuntime ?
-			(IResolveConstraint)Throws.Exception : Throws.Nothing;
 
 		static readonly Dictionary<string, ReusableConstraint> expectedCaseToConstraint_StructStatic =
 			ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				// TODO: StructFieldRefAccess
-				//["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
-				//["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
-				//["StructFieldRefAccess<T, F>(field)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
-				//["StructFieldRefAccess<T, F>(ref instance, field)"] = Throws.InstanceOf<ArgumentException>(),
-				["FieldRefAccess<T, F>(fieldName)(instance)"] = Throws.InstanceOf<ArgumentException>(), // TODO: will be non-compilable due to class constraint
-				["FieldRefAccess<T, F>(instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(), // TODO: will be non-compilable due to class constraint
+				["StructFieldRefAccess<T, F>(fieldName)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["StructFieldRefAccess<T, F>(ref instance, fieldName)"] = Throws.InstanceOf<ArgumentException>(),
+				["StructFieldRefAccess<T, F>(field)(ref instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["StructFieldRefAccess<T, F>(ref instance, field)"] = Throws.InstanceOf<ArgumentException>(),
 				["FieldRefAccess<F>(typeof(T), fieldName)(instance)"] = Throws.Nothing,
 				["FieldRefAccess<F>(typeof(T), fieldName)()"] = Throws.Nothing,
-				["FieldRefAccess<T, F>(field)(instance)"] = MonoThrowsException, // TODO: will be non-compilable due to class constraint
-				["FieldRefAccess<T, F>(field)()"] = MonoThrowsException, // TODO: will be non-compilable due to class constraint
 				["StaticFieldRefAccess<T, F>(fieldName)"] = Throws.Nothing,
 				["StaticFieldRefAccess<F>(typeof(T), fieldName)"] = Throws.Nothing,
 				["StaticFieldRefAccess<F>(field)()"] = Throws.Nothing,
@@ -607,17 +510,15 @@ namespace HarmonyLibTests
 			IncompatibleTypeT(expectedCaseToConstraint_StructInstance);
 
 		static readonly Dictionary<string, ReusableConstraint> expectedCaseToConstraint_ClassStatic_StructT =
-			StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint_StructStatic));
+			FieldMissingOnTypeT(expectedCaseToConstraint_StructStatic);
 
 		// AccessToolsStruct is compatible with object/ValueType/IAccessToolsType reference types (classes/interfaces), so NOT using IncompatibleTypeT here.
 		static readonly Dictionary<string, ReusableConstraint> expectedCaseToConstraint_StructInstance_ClassT =
 			FieldMissingOnTypeT(expectedCaseToConstraint_ClassInstance).Merge(ReusableConstraints(new Dictionary<string, IResolveConstraint>
 			{
-				["FieldRefAccess<T, F>(field)(instance)"] = SkipTest("struct instance can cause crash"), // TODO: should be ArgumentException
-				["FieldRefAccess<T, F>(field)()"] = Throws.TypeOf<NullReferenceException>(), // TODO: should be ArgumentException
-				//["FieldRefAccess<T, F>(instance, field)"] = Throws.InstanceOf<ArgumentException>(), // TODO: implement this overload
-				["StaticFieldRefAccess<F>(field)()"] = SkipTest("struct instance can cause crash"), // TODO: should be ArgumentException
-				["StaticFieldRefAccess<T, F>(field)"] = SkipTest("struct instance can cause crash"), // TODO: should be ArgumentException
+				["FieldRefAccess<T, F>(field)(instance)"] = Throws.InstanceOf<ArgumentException>(),
+				["FieldRefAccess<T, F>(field)()"] = Throws.InstanceOf<ArgumentException>(),
+				["FieldRefAccess<T, F>(instance, field)"] = Throws.InstanceOf<ArgumentException>(),
 			}));
 
 		static readonly Dictionary<string, ReusableConstraint> expectedCaseToConstraint_StructStatic_ClassT =
@@ -633,11 +534,11 @@ namespace HarmonyLibTests
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, string>(
 					field, "field1test", expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, string>(
-					field, "field1test", FieldInheritedBySubClass(expectedCaseToConstraint));
+					field, "field1test", expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsClass, AccessToolsSubClass, string>(
 					field, "field1test", expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsClass, string>(
-					field, "field1test", InterfaceT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, "field1test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsClass, string>(
 					field, "field1test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, string, string>(
@@ -652,10 +553,8 @@ namespace HarmonyLibTests
 					field, "field1test", expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, string[]>(
 					field, new[] { "should always throw" }, IncompatibleFieldType(expectedCaseToConstraint));
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix StaticFieldRefAccess to consistently throw ArgumentException when field type is incompatible with F.
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, int>(
-				//	field, 1337, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, int>(
+					field, 1337, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -665,15 +564,15 @@ namespace HarmonyLibTests
 			Assert.Multiple(() =>
 			{
 				var field = AccessTools.Field(typeof(AccessToolsClass), "field2");
-				var expectedCaseToConstraint = PublicField(expectedCaseToConstraint_ClassInstance);
+				var expectedCaseToConstraint = expectedCaseToConstraint_ClassInstance;
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, float>(
 					field, 314f, expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, float>(
-					field, 314f, FieldInheritedBySubClass(expectedCaseToConstraint));
+					field, 314f, expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsClass, AccessToolsSubClass, float>(
 					field, 314f, expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsClass, float>(
-					field, 314f, InterfaceT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, 314f, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsClass, float>(
 					field, 314f, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, string, float>(
@@ -682,18 +581,16 @@ namespace HarmonyLibTests
 					field, 314f, IncompatibleTypeT(expectedCaseToConstraint));
 				TestSuite_Struct<int, float>(
 					field, 314f, expectedCaseToConstraint_ClassInstance_StructT);
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix *FieldRefAccess to consistently throw ArgumentException when field type is a value type and F is a different type.
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, object>(
-				//	field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, ValueType>(
-				//	field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, float?>(
-				//	field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, IComparable>(
-				//	field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, double>(
-				//	field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, object>(
+					field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, ValueType>(
+					field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, float?>(
+					field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, IComparable>(
+					field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, double>(
+					field, 314f, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -703,34 +600,32 @@ namespace HarmonyLibTests
 			Assert.Multiple(() =>
 			{
 				var field = AccessTools.Field(typeof(AccessToolsClass), "field3");
-				var expectedCaseToConstraint = PublicField(expectedCaseToConstraint_ClassStatic);
+				var expectedCaseToConstraint = expectedCaseToConstraint_ClassStatic;
 				// Note: As this is as static field, instance type is ignored, so IncompatibleInstanceType is never needed.
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, long>(
 					field, 314L, expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, long>(
-					field, 314L, FieldNotInheritedBySubClass(expectedCaseToConstraint));
+					field, 314L, expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsClass, long>(
-					field, 314L, InterfaceT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, 314L, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsClass, long>(
 					field, 314L, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, string, long>(
 					field, 314L, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<string, string, long>(
-					field, 314L, StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, 314L, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Struct<int, long>(
-					field, 314L, PublicField(expectedCaseToConstraint_ClassStatic_StructT));
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix *FieldRefAccess to consistently throw ArgumentException when field type is a value type and F is a different type.
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, object>(
-				//	field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, ValueType>(
-				//	field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, long?>(
-				//	field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, IComparable>(
-				//	field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, double>(
-				//	field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
+					field, 314L, expectedCaseToConstraint_ClassStatic_StructT);
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, object>(
+					field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, ValueType>(
+					field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, long?>(
+					field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, IComparable>(
+					field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, double>(
+					field, 314L, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -745,15 +640,15 @@ namespace HarmonyLibTests
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, string>(
 					field, "field4test", expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, string>(
-					field, "field4test", FieldNotInheritedBySubClass(expectedCaseToConstraint));
+					field, "field4test", expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsClass, string>(
-					field, "field4test", InterfaceT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, "field4test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsClass, string>(
 					field, "field4test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, string, string>(
 					field, "field4test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<string, string, string>(
-					field, "field4test", StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, "field4test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Struct<int, string>(
 					field, "field4test", expectedCaseToConstraint_ClassStatic_StructT);
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, object>(
@@ -762,10 +657,8 @@ namespace HarmonyLibTests
 					field, "field4test", expectedCaseToConstraint);
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, IEnumerable<string>>(
 					field, new[] { "should always throw" }, IncompatibleFieldType(expectedCaseToConstraint));
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix StaticFieldRefAccess to consistently throw ArgumentException when field type is incompatible with F.
-				//TestSuite_Class<AccessToolsClass, AccessToolsClass, int>(
-				//	field, 1337, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, int>(
+					field, 1337, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -776,14 +669,14 @@ namespace HarmonyLibTests
 			{
 				var field = AccessTools.Field(typeof(AccessToolsSubClass), "subclassField1");
 				var expectedCaseToConstraint = expectedCaseToConstraint_ClassInstance;
-				TestSuite_Class<AccessToolsClass, AccessToolsClass, string>( // TODO: should be IncompatibleInstanceType once T=object special-casing is generalized
-					field, "subclassField1test", IncompatibleTypeT(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsClass, string>(
+					field, "subclassField1test", IncompatibleInstanceType(expectedCaseToConstraint));
 				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, string>(
 					field, "subclassField1test", expectedCaseToConstraint);
-				TestSuite_Class<AccessToolsClass, AccessToolsSubClass, string>( // TODO: should be FieldMissingOnTypeT once T=object special-casing is generalized
-					field, "subclassField1test", IncompatibleTypeT(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsClass, AccessToolsSubClass, string>(
+					field, "subclassField1test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<IAccessToolsType, AccessToolsSubClass, string>(
-					field, "subclassField1test", InterfaceT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, "subclassField1test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsSubClass, string>(
 					field, "subclassField1test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsClass, string>(
@@ -812,11 +705,11 @@ namespace HarmonyLibTests
 				var expectedCaseToConstraint = expectedCaseToConstraint_ClassStatic;
 				// Note: As this is as static field, instance type is ignored, so IncompatibleInstanceType is never needed.
 				TestSuite_Class<AccessToolsClass, AccessToolsClass, int>(
-					field, 123, StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, 123, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, int>(
 					field, 123, expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsSubClass, int>(
-					field, 123, InterfaceT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, 123, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsSubClass, int>(
 					field, 123, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<object, AccessToolsClass, int>(
@@ -824,21 +717,19 @@ namespace HarmonyLibTests
 				TestSuite_Class<object, string, int>(
 					field, 123, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Class<string, string, int>(
-					field, 123, StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, 123, FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Struct<int, int>(
 					field, 123, expectedCaseToConstraint_ClassStatic_StructT);
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix *FieldRefAccess to consistently throw ArgumentException when field type is a value type and F is a different type.
-				//TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, object>(
-				//	field, 123, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, ValueType>(
-				//	field, 123, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, int?>(
-				//	field, 123, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, IComparable>(
-				//	field, 123, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, double>(
-				//	field, 123, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, object>(
+					field, 123, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, ValueType>(
+					field, 123, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, int?>(
+					field, 123, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, IComparable>(
+					field, 123, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Class<AccessToolsSubClass, AccessToolsSubClass, double>(
+					field, 123, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -848,12 +739,12 @@ namespace HarmonyLibTests
 			Assert.Multiple(() =>
 			{
 				var field = AccessTools.Field(typeof(AccessToolsStruct), "structField1");
-				var expectedCaseToConstraint = PublicField(expectedCaseToConstraint_StructInstance);
+				var expectedCaseToConstraint = expectedCaseToConstraint_StructInstance;
 				var expectedCaseToConstraintClassT = expectedCaseToConstraint_StructInstance_ClassT;
 				TestSuite_Struct<AccessToolsStruct, string>(
 					field, "structField1test", expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsStruct, string>(
-					field, "structField1test", InterfaceT(expectedCaseToConstraintClassT));
+					field, "structField1test", expectedCaseToConstraintClassT);
 				TestSuite_Class<object, AccessToolsStruct, string>(
 					field, "structField1test", expectedCaseToConstraintClassT);
 				TestSuite_Class<object, string, string>(
@@ -882,7 +773,7 @@ namespace HarmonyLibTests
 				TestSuite_Struct<AccessToolsStruct, int>(
 					field, 1234, expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsStruct, int>(
-					field, 1234, InterfaceT(expectedCaseToConstraintClassT));
+					field, 1234, expectedCaseToConstraintClassT);
 				TestSuite_Class<object, AccessToolsStruct, int>(
 					field, 1234, expectedCaseToConstraintClassT);
 				TestSuite_Class<object, string, int>(
@@ -891,18 +782,16 @@ namespace HarmonyLibTests
 					field, 1234, IncompatibleTypeT(expectedCaseToConstraintClassT));
 				TestSuite_Struct<int, int>(
 					field, 1234, IncompatibleTypeT(expectedCaseToConstraint));
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix *FieldRefAccess to consistently throw ArgumentException when field type is a value type and F is a different type.
-				//TestSuite_Struct<AccessToolsStruct, object>(
-				//	field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, ValueType>(
-				//	field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, int?>(
-				//	field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, IComparable>(
-				//	field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, long>(
-				//	field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, object>(
+					field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, ValueType>(
+					field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, int?>(
+					field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, IComparable>(
+					field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, long>(
+					field, 1234, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -918,27 +807,25 @@ namespace HarmonyLibTests
 				TestSuite_Struct<AccessToolsStruct, int>(
 					field, 4321, expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsStruct, int>(
-					field, 4321, InterfaceT(expectedCaseToConstraintClassT));
+					field, 4321, expectedCaseToConstraintClassT);
 				TestSuite_Class<object, AccessToolsStruct, int>(
 					field, 4321, expectedCaseToConstraintClassT);
 				TestSuite_Class<object, string, int>(
 					field, 4321, expectedCaseToConstraintClassT);
 				TestSuite_Class<string, string, int>(
-					field, 4321, StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraintClassT)));
+					field, 4321, FieldMissingOnTypeT(expectedCaseToConstraintClassT));
 				TestSuite_Struct<int, int>(
-					field, 4321, StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint)));
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix StaticFieldRefAccess to consistently throw ArgumentException when field type is incompatible with F.
-				//TestSuite_Struct<AccessToolsStruct, object>(
-				//	field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, ValueType>(
-				//	field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, int?>(
-				//	field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, IComparable>(
-				//	field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
-				//TestSuite_Struct<AccessToolsStruct, long>(
-				//	field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
+					field, 4321, FieldMissingOnTypeT(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, object>(
+					field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, ValueType>(
+					field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, int?>(
+					field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, IComparable>(
+					field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, long>(
+					field, 4321, IncompatibleFieldType(expectedCaseToConstraint));
 			});
 		}
 
@@ -948,126 +835,28 @@ namespace HarmonyLibTests
 			Assert.Multiple(() =>
 			{
 				var field = AccessTools.Field(typeof(AccessToolsStruct), "structField4");
-				var expectedCaseToConstraint = PublicField(expectedCaseToConstraint_StructStatic);
-				var expectedCaseToConstraintClassT = PublicField(expectedCaseToConstraint_StructStatic_ClassT);
+				var expectedCaseToConstraint = expectedCaseToConstraint_StructStatic;
+				var expectedCaseToConstraintClassT = expectedCaseToConstraint_StructStatic_ClassT;
 				// Note: As this is as static field, instance type is ignored, so IncompatibleInstanceType is never needed.
 				TestSuite_Struct<AccessToolsStruct, string>(
 					field, "structField4test", expectedCaseToConstraint);
 				TestSuite_Class<IAccessToolsType, AccessToolsStruct, string>(
-					field, "structField4test", InterfaceT(expectedCaseToConstraintClassT));
+					field, "structField4test", expectedCaseToConstraintClassT);
 				TestSuite_Class<object, AccessToolsStruct, string>(
 					field, "structField4test", expectedCaseToConstraintClassT);
 				TestSuite_Class<object, string, string>(
 					field, "structField4test", expectedCaseToConstraintClassT);
 				TestSuite_Class<string, string, string>(
-					field, "structField4test", StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraintClassT)));
+					field, "structField4test", FieldMissingOnTypeT(expectedCaseToConstraintClassT));
 				TestSuite_Struct<int, string>(
-					field, "structField4test", StaticIncompatibleTypeT(FieldMissingOnTypeT(expectedCaseToConstraint)));
+					field, "structField4test", FieldMissingOnTypeT(expectedCaseToConstraint));
 				TestSuite_Struct<AccessToolsStruct, object>(
 					field, "structField4test", expectedCaseToConstraint);
 				TestSuite_Struct<AccessToolsStruct, IComparable>(
 					field, "structField4test", expectedCaseToConstraint);
-				// TODO: Following tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error.
-				// Fix StaticFieldRefAccess to consistently throw ArgumentException when field type is incompatible with F.
-				//TestSuite_Struct<AccessToolsStruct, int>(
-				//	field, 1337, IncompatibleFieldType(expectedCaseToConstraint));
+				TestSuite_Struct<AccessToolsStruct, int>(
+					field, 1337, IncompatibleFieldType(expectedCaseToConstraint));
 			});
-		}
-
-		// TODO: Fix FieldRefAccess to consistently throw ArgumentException for struct instance fields,
-		// removing the need for these separate explicit tests.
-		static void TestCase_StructInstance_CanCrash<T, F>(string fieldName, F testValue, string testCaseName) where T : struct
-		{
-			var field = AccessTools.Field(typeof(T), fieldName);
-			// Superset of problematic test cases
-			var availableTestCases = Merge(
-				AvailableTestCases_FieldRefAccess_Struct_ByName<T, F>(fieldName),
-				AvailableTestCases_FieldRefAccess_Struct_ByFieldInfo<T, F>(field),
-				AvailableTestCases_StaticFieldRefAccess_ByFieldInfo<T, F>(field));
-			TestCase_CanCrash(testValue, testCaseName, field, availableTestCases);
-		}
-
-		// TODO: Fix FieldRefAccess to consistently throw ArgumentException when field type is a value type and F is a different type,
-		// removing the need for these separate explicit tests.
-		static void TestCase_ClassInstance_ValueTypeField_DifferentF_CanCrash<T, F>(string fieldName, F testValue,
-			string testCaseName) where T : class
-		{
-			var field = AccessTools.Field(typeof(T), fieldName);
-			// Superset of problematic test cases
-			var availableTestCases = AvailableTestCases_FieldRefAccess_Class_ByFieldInfo<T, F>(field);
-			TestCase_CanCrash(testValue, testCaseName, field, availableTestCases);
-		}
-
-		// TODO: Fix StaticFieldRefAccess to consistently throw ArgumentException when field type is incompatible with F,
-		// (specifically: if field type is reference type, any value type F; if field type is value type, any different F)
-		// removing the need for these separate explicit tests.
-		static void TestCase_Static_IncompatibleF_CanCrash<T, F>(string fieldName, F testValue,
-			string testCaseName)
-		{
-			var field = AccessTools.Field(typeof(T), fieldName);
-			// Superset of problematic test cases
-			var availableTestCases = AvailableTestCases_StaticFieldRefAccess_ByFieldInfo<T, F>(field);
-			TestCase_CanCrash(testValue, testCaseName, field, availableTestCases);
-		}
-
-		static void TestCase_CanCrash<T, F>(F testValue, string testCaseName, FieldInfo field,
-			Dictionary<string, IATestCase<T, F>> availableTestCases)
-		{
-			var instance = CloneInstancePrototype<T>(typeof(T));
-			try
-			{
-				var origValue = field.GetValue(instance);
-				var testCase = availableTestCases[testCaseName];
-				var value = testCase.Get(ref instance);
-				Assert.AreNotEqual(testValue, value, "expected !Equals(testValue, value) (before set)");
-				testCase.Set(ref instance, testValue);
-				var currentValue = field.GetValue(instance);
-				Assert.AreNotEqual(testValue, currentValue, "expected !Equals(testValue, field.GetValue(instance)) (after set)");
-				Console.Error.WriteLine($"Test failed as expected: origValue={origValue}, testValue={testValue}, currentValue={currentValue}");
-			}
-			catch (Exception ex) when (ex is InvalidProgramException || ex is NullReferenceException || ex is AccessViolationException)
-			{
-				// If an assertion failure or fatal crash hasn't happened yet, any of the above exceptions could be thrown,
-				// depending on the environment.
-				Console.Error.WriteLine("Test is known to sometimes throw:\n" + ex);
-			}
-		}
-
-		[Test, Explicit("These tests will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error")]
-		[TestCase(typeof(AccessToolsStruct), typeof(string), "structField1", "structField1testcrash", "FieldRefAccess<T, F>(field)(instance)")]
-		[TestCase(typeof(AccessToolsStruct), typeof(string), "structField1", "structField1testcrash", "FieldRefAccess<F>(typeof(T), fieldName)(instance)")]
-		[TestCase(typeof(AccessToolsStruct), typeof(string), "structField1", "structField1testcrash", "StaticFieldRefAccess<F>(field)()")]
-		[TestCase(typeof(AccessToolsStruct), typeof(int), "structField2", 1234, "FieldRefAccess<T, F>(field)(instance)")]
-		[TestCase(typeof(AccessToolsStruct), typeof(int), "structField2", 1234, "FieldRefAccess<F>(typeof(T), fieldName)(instance)")]
-		[TestCase(typeof(AccessToolsStruct), typeof(int), "structField2", 1234, "StaticFieldRefAccess<F>(field)()")]
-		public void Test_StructInstance_CanCrash(Type typeT, Type typeF, string fieldName, object testValue, string testCaseName)
-		{
-			TestTools.AssertIgnoreIfVSTest(); // uncomment this to actually run the test in Visual Studio
-			var method = AccessTools.Method(typeof(TestFieldRefAccess), nameof(TestCase_StructInstance_CanCrash));
-			_ = method.MakeGenericMethod(typeT, typeF).Invoke(this, new object[] { fieldName, testValue, testCaseName });
-		}
-
-		[Test, Explicit("This test will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error")]
-		[TestCase(typeof(AccessToolsClass), typeof(object), "field2", 123f, "FieldRefAccess<T, F>(field)(instance)")] // field2 is non-static float
-		[TestCase(typeof(AccessToolsClass), typeof(float?), "field2", 123f, "FieldRefAccess<T, F>(field)(instance)")]
-		[TestCase(typeof(AccessToolsClass), typeof(IComparable), "field2", 123f, "FieldRefAccess<T, F>(field)(instance)")]
-		public void Test_ClassInstance_ValueTypeField_DifferentF_CanCrash(Type typeT, Type typeF, string fieldName, object testValue, string testCaseName)
-		{
-			TestTools.AssertIgnoreIfVSTest(); // uncomment this to actually run the test in Visual Studio
-			var method = AccessTools.Method(typeof(TestFieldRefAccess), nameof(TestCase_ClassInstance_ValueTypeField_DifferentF_CanCrash));
-			_ = method.MakeGenericMethod(typeT, typeF).Invoke(this, new object[] { fieldName, testValue, testCaseName });
-		}
-
-		[Test, Explicit("This test will either fail to get/set correctly or crash the runtime due to invalid IL code causing some fatal error")]
-		[TestCase(typeof(AccessToolsClass), typeof(int), "field4", 321, "StaticFieldRefAccess<F>(field)()")] // field4 is static string
-		[TestCase(typeof(AccessToolsStruct), typeof(object), "structField3", 456, "StaticFieldRefAccess<F>(field)()")] // structField3 is static int
-		[TestCase(typeof(AccessToolsStruct), typeof(int?), "structField3", 456, "StaticFieldRefAccess<F>(field)()")]
-		[TestCase(typeof(AccessToolsStruct), typeof(IComparable), "structField3", 456, "StaticFieldRefAccess<F>(field)()")]
-		public void Test_Static_IncompatibleF_CanCrash(Type typeT, Type typeF, string fieldName, object testValue, string testCaseName)
-		{
-			TestTools.AssertIgnoreIfVSTest(); // uncomment this to actually run the test in Visual Studio
-			var method = AccessTools.Method(typeof(TestFieldRefAccess), nameof(TestCase_Static_IncompatibleF_CanCrash));
-			_ = method.MakeGenericMethod(typeT, typeF).Invoke(this, new object[] { fieldName, testValue, testCaseName });
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Followup on #321
* Add `AccessTools.StructFieldRef` and `StructFieldRefAccess` for struct support.
* For existing `AccessTools.FieldRefAccess` and `AccessTools.StaticFieldRefAccess` methods, handle edge cases and have consistent error handling, as exhaustively documented via `TestFieldRefAccess`.
* Also fixes `AccessTools.FindIncludingBaseTypes` (and thus all the methods that rely on it) NRE on interface types and unknown members.
* Improve related XML docs and some code consistency.

## Details and testing
These changes have tested for binary compatibility with versions before this change on:
* Mono runtime (.NET Framework 3.5+ equivalent)
* CLR 4 (.NET Framework 4+)
* CoreCLR (.NET Core 3+)

where "binary compatibility" here specifically means that any pre-change usage that results in an exception or crash (or undefined behavior) now results in either no exception, the same exception, or a different exception. In other words, if it was "broken" before, it either now works or throws an exception (and that thrown exception is now consistent across use cases).

The non-Mono runtimes throw `VerificationException` (`type argument 'T' violates the constraint of type parameter 'T'`) when calling `FieldRefAccess` methods with `T` being a struct type, but in such cases, they were already broken in both Mono and non-Mono runtimes, with one exception:

For static fields and `T` being a struct type, `AccessTools.FieldRefAccess<T, F>(field)` worked on non-Mono runtimes (due to IL verification leniency with `ldflda`). It now throws `VerificationException` due to the generic class constraint. I consider this an acceptable exception, since this should be a very rare and undocumented use case (and now longer compilable given the generic class constraint), especially given most usage of Harmony is on Unity/Mono runtimes.

Interestingly, this same use case on Mono runtimes throws `InvalidProgramException` pre-change and now works post-change, since Mono doesn't do the same generic constraint runtime checks that CLR/CoreCLR is doing. This still meets my "binary compatibility" definition above, and furthermore such code is no longer compilable anyway given the generic class constraint.

See attached log files for the gory details:
[TestFieldRefAccess.net472.log](https://github.com/lbmaian/Harmony/files/4945098/TestFieldRefAccess.net472.log)
[TestFieldRefAccess.netcoreapp3.1.log](https://github.com/lbmaian/Harmony/files/4945099/TestFieldRefAccess.netcoreapp3.1.log)
[TestFieldRefAccess.mono.net35.log](https://github.com/lbmaian/Harmony/files/4945100/TestFieldRefAccess.mono.net35.log)
[TestFieldRefAccess.mono.net472.log](https://github.com/lbmaian/Harmony/files/4945101/TestFieldRefAccess.mono.net472.log)

They're created by building pre-change, copying bin folder to bin-old, building post-change, copying only 0Harmony.* files over to bin-old, and running:
```
dotnet test HarmonyTests/bin-old/Debug/net472/HarmonyTests.dll --logger console --filter HarmonyLibTests.TestFieldRefAccess > TestFieldRefAccess.net472.log
dotnet test HarmonyTests/bin-old/Debug/netcoreapp3.1/HarmonyTests.dll --logger console --filter HarmonyLibTests.TestFieldRefAccess > TestFieldRefAccess.netcoreapp3.1.log
mono path/to/nunit3-console.exe HarmonyTests/bin-old/Debug/net35/HarmonyTests.dll --test HarmonyLibTests.TestFieldRefAccess > TestFieldRefAccess.mono.net35.log
mono path/to/nunit3-console.exe HarmonyTests/bin-old/Debug/net472/HarmonyTests.dll --test HarmonyLibTests.TestFieldRefAccess > TestFieldRefAccess.mono.net472.log
```