### PR TITLE
Expand documentation for patching generics

### DIFF
--- a/docs/articles/patching-edgecases.html
+++ b/docs/articles/patching-edgecases.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <!--[if IE]><![endif]-->
 <html>
   
@@ -114,8 +114,13 @@ public class SubClass : BaseClass
 </code></pre>
 <p>The reason for this is that the resolution of <code>base.SomeMethod()</code> happens in your compiler. It will create IL code that targets that specific method. At runtime however, you can't simply use reflections or delegates to call it. They all will be resolved to the overwriting method. The only solution that is known to solve this is to use a <code>Reverse Patch</code> that copies the original to a stub of your own that you then can call. See this <a href="https://gist.github.com/pardeike/45196a8b8ef331f38b14e1a7e5ee1782">gist</a> for an example and a comparison.</p>
 <h3 id="generics">Generics</h3>
-<p>Methods that contains generics like <code>Add</code> in <code>List&lt;T&gt;.Add(...)</code> or methods defined in classes that are generic can be patched but you might get unexpected results. Usually you need to patch specific implementations separately, patching each type of T on its own.</p>
-<p>Other times, patching such a method can make the runtime call your patch for types of T that you do not expect. The solution for that is to inject <code>__instance</code> and check its type and run your patch code conditionally.</p>
+<p>Generics can be difficult to patch. In general, expect generic methods and methods of generic classes to be shared between different types of <code>T</code> during runtime. This means that by patching one method, the method will be patched for all types of <code>T</code>. Depending on the type of generic and your .NET runtime, this can be worked around in a few ways:</p>
+<ul>
+<li>If the generic includes a value type, such as <code>int</code>, in most (but not all) cases, the method will not be shared. Patching a method which uses a value type parameter will patch only that specific method. Conversely, patching a generic with an object type will <em>not</em> patch the value type method, so both may have to be patched.</li>
+<li>If the method is a non-generic non-static method of a generic class, you can check the generic type using <code>__instance</code> (such as <code>__instance.GetType().DeclaringType.GenericTypeArguments</code>), and adjust your code's behavior depending on the type.</li>
+<li>If the method is a generic method of a non-generic class, you may be able to examine the method's arguments, if any argument contains <code>T</code>. Also, generic type data will be lost (if <code>Method&lt;T&gt;</code> is patched using <code>Method&lt;string&gt;</code>, <code>Method&lt;object&gt;</code> will become <code>Method&lt;string&gt;</code>)</li>
+<li>If the method is a static non-generic method of a generic class, generic type data will be lost (see above).</li>
+</ul>
 <h3 id="static-constructors">Static Constructors</h3>
 <p>Static constructors of a class will run as soon as you touch or instantiate that class. That unfortunately means that when Harmony asks for some basic required information for that class, it will trigger the static constructor before the patch happens.</p>
 <p>As a result, you cannot patch static constructors unless you plan to run them again (which often defeats the purpose). It also as the side effect that your patches to other methods in such a class will run the constructor at the wrong moment - causing errors. In that case, you need to time the patching so it happens when its ok to run the static constructor or when it already has been triggered.</p>


### PR DESCRIPTION
Expand the documentation for patching generic types based on information learned from Mono blog posts, documentation, and experimentation.