### PR TITLE
Patch static generic methods

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -25,6 +25,7 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>7.3</LangVersion>
 		<DefaultItemExcludes>$(DefaultItemExcludes);Documentation/**</DefaultItemExcludes>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 	</PropertyGroup>
 
 	<Choose>
@@ -48,22 +49,23 @@
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<Optimize>false</Optimize>
-		<DebugType>full</DebugType>
+		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<DefineConstants>DEBUG</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<Optimize>true</Optimize>
-		<DebugType>none</DebugType>
-		<DebugSymbols>false</DebugSymbols>
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net35|AnyCPU'">
+	  <DefineConstants>TRACE;DEBUG</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<!-- https://dev.azure.com/MonoMod/MonoMod/_packaging?_a=feed&feed=DevBuilds -->
-		<PackageReference Include="MonoMod.Common" Version="20.5.31.1">
-			<PrivateAssets Condition="!$(IsCoreOrStandard) And '$(Configuration)'=='Release'">All</PrivateAssets>
-		</PackageReference>
 
 		<!-- Reference assemblies are needed for non-Windows .NET Framework targeting builds. -->
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
@@ -87,6 +89,24 @@
 			<HintPath>..\libs\System.Reflection.Emit.Lightweight.dll</HintPath>
 			<Private>true</Private>
 		</Reference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Reference Include="Mono.Cecil">
+	    <HintPath>..\..\MonoMod\MonoMod.Common\bin\Debug\net40\Mono.Cecil.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Mono.Cecil.Mdb">
+	    <HintPath>..\..\MonoMod\MonoMod.Common\bin\Debug\net40\Mono.Cecil.Mdb.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Mono.Cecil.Pdb">
+	    <HintPath>..\..\MonoMod\MonoMod.Common\bin\Debug\net40\Mono.Cecil.Pdb.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Mono.Cecil.Rocks">
+	    <HintPath>..\..\MonoMod\MonoMod.Common\bin\Debug\net40\Mono.Cecil.Rocks.dll</HintPath>
+	  </Reference>
+	  <Reference Include="MonoMod.Common">
+	    <HintPath>..\..\MonoMod\MonoMod.Common\bin\Debug\net40\MonoMod.Common.dll</HintPath>
+	  </Reference>
 	</ItemGroup>
 
 	<Target Name="RemoveOldNuGetPackages" BeforeTargets="PreBuildEvent">
@@ -120,7 +140,7 @@
 			<WorkingDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(TargetFramework)</WorkingDirectory>
 		</PropertyGroup>
 		<ItemGroup>
-			<UnnecessaryDependencyFiles Include="$(WorkingDirectory)\*" Exclude="$(WorkingDirectory)\$(AssemblyName).*"/>
+			<UnnecessaryDependencyFiles Include="$(WorkingDirectory)\*" Exclude="$(WorkingDirectory)\$(AssemblyName).*" />
 		</ItemGroup>
 		<Delete Files="@(UnnecessaryDependencyFiles)" />
 	</Target>

--- a/Harmony/Internal/Emitter.cs
+++ b/Harmony/Internal/Emitter.cs
@@ -95,6 +95,7 @@ namespace HarmonyLib
 
 		internal static string FormatArgument(object argument, string extra = null)
 		{
+			return argument.ToString().Trim();
 			if (argument == null) return "NULL";
 			var type = argument.GetType();
 

--- a/Harmony/Internal/PatchFunctions.cs
+++ b/Harmony/Internal/PatchFunctions.cs
@@ -152,7 +152,14 @@ namespace HarmonyLib
 
 			try
 			{
-				Memory.DetourMethodAndPersist(original, replacement);
+				if (original.IsGenericMethodDefinition)
+				{
+					Memory.DetourMethodAndPersist(((MethodInfo)original).MakeGenericMethod(typeof(object), typeof(object)), replacement);
+				}
+				else
+				{
+					Memory.DetourMethodAndPersist(original, replacement);
+				}
 			}
 			catch (Exception ex)
 			{

--- a/Harmony/Properties/launchSettings.json
+++ b/Harmony/Properties/launchSettings.json
@@ -3,7 +3,8 @@
     "Harmony": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files (x86)\\RimWorld1722Win\\RimWorld1722Win.exe",
-      "workingDirectory": "C:\\Program Files (x86)\\RimWorld1722Win\\"
+      "workingDirectory": "C:\\Program Files (x86)\\RimWorld1722Win\\",
+      "nativeDebugging": false
     }
   }
 }


### PR DESCRIPTION
This adds support for patching generic methods. Instead of `Method<string>` being patched and all `Method<referenceType>` becoming `Method<string>`, `Method<>` is patched, and then the runtime can generate generics using `MakeGenericMethod`.

Currently, static generic methods of non-generic classes can be patched, and maintain their type information. 

Requires the [MonoMod.Common changes here](https://github.com/MonoMod/MonoMod.Common/pull/8).