### PR TITLE
Fix a DirectoryNotFoundException at FileLog

### DIFF
--- a/Harmony/Tools/FileLog.cs
+++ b/Harmony/Tools/FileLog.cs
@@ -94,6 +94,9 @@ namespace HarmonyLib
 		{
 			lock (logPath)
 			{
+				// To make sure the directory is created, because linux servers don't create it by default 
+				Directory.CreateDirectory(Path.GetDirectoryName(logPath));
+
 				if (buffer.Count > 0)
 				{
 					using (var writer = File.AppendText(logPath))


### PR DESCRIPTION
This PR fixes a `DirectoryNotFoundException` at FileLog when it tries to log into a file on a docker container. `Environment.GetFolderPath(Environment.SpecialFolder.Desktop)` returns `/home/container/Desktop`, but this directory doesn't exists by default, and it causes a `DirectoryNotFoundException`.