### PR TITLE
More thread-safety

### DIFF
--- a/Harmony/Internal/HarmonySharedState.cs
+++ b/Harmony/Internal/HarmonySharedState.cs
@@ -88,7 +88,7 @@ namespace HarmonyLib
 		internal static IEnumerable<MethodBase> GetPatchedMethods()
 		{
 			var state = GetState();
-			lock (state) return state.Keys;
+			lock (state) return state.Keys.ToArray();
 		}
 
 		internal static void UpdatePatchInfo(MethodBase method, PatchInfo patchInfo)

--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -8,6 +8,9 @@ namespace HarmonyLib
 {
 	internal static class PatchTools
 	{
+		// Note: Even though this Dictionary is only stored to and never read from, it still needs to be thread-safe:
+		// https://stackoverflow.com/a/33153868
+		[ThreadStatic]
 		static readonly Dictionary<object, object> objectReferences = new Dictionary<object, object>();
 
 		internal static void RememberObject(object key, object value)

--- a/Harmony/Internal/StructReturnBufferCheck.cs
+++ b/Harmony/Internal/StructReturnBufferCheck.cs
@@ -81,9 +81,7 @@ namespace HarmonyLib
 
 	internal class StructReturnBuffer
 	{
-#pragma warning disable IDE0044 // so tests can reset it
-		static Dictionary<Type, int> sizes = new Dictionary<Type, int>();
-#pragma warning restore IDE0044
+		static readonly Dictionary<Type, int> sizes = new Dictionary<Type, int>();
 
 		static int SizeOf(Type type)
 		{
@@ -163,7 +161,7 @@ namespace HarmonyLib
 			//
 			//        insert
 			//          |
-			//          V 
+			//          V
 			// THIS , IntPtr , arg0 , arg1 , arg2 ...
 			//
 			// So we make space at index 1 by moving all Ldarg_[n] to Ldarg_[n+1]
@@ -173,7 +171,7 @@ namespace HarmonyLib
 			//
 			//  insert
 			//    |
-			//    V 
+			//    V
 			// +IntPtr , arg0 , arg1 , arg2 ...
 			//
 			// So we make space at index 0 by moving all Ldarg_[n] to Ldarg_[n+1]

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -12,12 +12,13 @@ using System.Runtime.Serialization;
 namespace HarmonyLib
 {
 	/// <summary>A helper class for reflection related functions</summary>
-	/// 
+	///
 	public static class AccessTools
 	{
 		/// <summary>Shortcut for <see cref="BindingFlags"/> to simplify the use of reflections and make it work for any access level</summary>
-		/// 
-		public static BindingFlags all = BindingFlags.Public
+		///
+		// Note: This should a be const, but changing from static (readonly) to const breaks binary compatibility.
+		public static readonly BindingFlags all = BindingFlags.Public
 			| BindingFlags.NonPublic
 			| BindingFlags.Instance
 			| BindingFlags.Static
@@ -27,8 +28,9 @@ namespace HarmonyLib
 			| BindingFlags.SetProperty;
 
 		/// <summary>Shortcut for <see cref="BindingFlags"/> to simplify the use of reflections and make it work for any access level but only within the current type</summary>
-		/// 
-		public static BindingFlags allDeclared = all | BindingFlags.DeclaredOnly;
+		///
+		// Note: This should a be const, but changing from static (readonly) to const breaks binary compatibility.
+		public static readonly BindingFlags allDeclared = all | BindingFlags.DeclaredOnly;
 
 		/// <summary>Gets a type by name. Prefers a full name with namespace but falls back to the first type matching the name otherwise</summary>
 		/// <param name="name">The name</param>
@@ -59,7 +61,7 @@ namespace HarmonyLib
 		/// If such an exception is thrown, returns the successfully loaded types (<see cref="ReflectionTypeLoadException.Types"/>,
 		/// filtered for non-null values).
 		/// </remarks>
-		/// 
+		///
 		public static Type[] GetTypesFromAssembly(Assembly assembly)
 		{
 			try
@@ -1386,7 +1388,7 @@ namespace HarmonyLib
 		/// and both class and struct methods.
 		/// </para>
 		/// </remarks>
-		/// 
+		///
 		public static DelegateType MethodDelegate<DelegateType>(MethodInfo method, object instance = null, bool virtualCall = true) where DelegateType : Delegate
 		{
 			if (method is null)
@@ -1534,7 +1536,7 @@ namespace HarmonyLib
 		/// determined from the [<see cref="HarmonyLib.HarmonyDelegate"/>] attributes on <typeparamref name="DelegateType"/>,
 		/// and the given <paramref name="instance"/> (for closed instance delegates).
 		/// </remarks>
-		/// 
+		///
 		public static DelegateType HarmonyDelegate<DelegateType>(object instance = null) where DelegateType : Delegate
 		{
 			var harmonyMethod = HarmonyMethodExtensions.GetMergedFromType(typeof(DelegateType));
@@ -1765,7 +1767,7 @@ namespace HarmonyLib
 		/// <summary>Tests if a type is an integer type</summary>
 		/// <param name="type">The type</param>
 		/// <returns>True if the type represents some integer</returns>
-		/// 
+		///
 		public static bool IsInteger(Type type)
 		{
 			switch (Type.GetTypeCode(type))
@@ -1787,7 +1789,7 @@ namespace HarmonyLib
 		/// <summary>Tests if a type is a floating point type</summary>
 		/// <param name="type">The type</param>
 		/// <returns>True if the type represents some floating point</returns>
-		/// 
+		///
 		public static bool IsFloatingPoint(Type type)
 		{
 			switch (Type.GetTypeCode(type))

--- a/Harmony/Tools/FileLog.cs
+++ b/Harmony/Tools/FileLog.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace HarmonyLib
 {
 	/// <summary>A file log for debugging</summary>
-	/// 
+	///
 	public static class FileLog
 	{
 		private static readonly object fileLock = new object();
@@ -25,11 +25,11 @@ namespace HarmonyLib
 		public static string logPath;
 
 		/// <summary>The indent character. The default is <c>tab</c></summary>
-		/// 
+		///
 		public static char indentChar = '\t';
 
 		/// <summary>The current indent level</summary>
-		/// 
+		///
 		public static int indentLevel = 0;
 
 		static List<string> buffer = new List<string>();
@@ -44,7 +44,10 @@ namespace HarmonyLib
 		///
 		public static void ChangeIndent(int delta)
 		{
-			indentLevel = Math.Max(0, indentLevel + delta);
+			lock (fileLock)
+			{
+				indentLevel = Math.Max(0, indentLevel + delta);
+			}
 		}
 
 		/// <summary>Log a string in a buffered way. Use this method only if you are sure that FlushBuffer will be called
@@ -98,7 +101,7 @@ namespace HarmonyLib
 		}
 
 		/// <summary>Flushes the log buffer to disk (use in combination with LogBuffered)</summary>
-		/// 
+		///
 		public static void FlushBuffer()
 		{
 			lock (fileLock)
@@ -128,7 +131,7 @@ namespace HarmonyLib
 		}
 
 		/// <summary>Resets and deletes the log</summary>
-		/// 
+		///
 		public static void Reset()
 		{
 			lock (fileLock)


### PR DESCRIPTION
`HarmonySharedState`:
- A lock on a `const` string doesn't look safe (might be safe due to the interned string, but let's not bank on it), so locking on an explicit lock object.
- Also locking over the whole operation, rather than just on `GetState`.

`PatchTools`:
- Attributed `objectReferences` with `ThreadStatic`. Even though this Dictionary is only stored to and never read from, it still needs to be thread-safe: https://stackoverflow.com/a/33153868

`AccessTools`:
- Make `AccessTools.all`/`allDeclared` `static readonly`, with a note on why they're not `const` (would break binary compatibility). I'm making the probably safe assumption that no one ever sets these fields.

Other changes:
- Revert `StructReturnBuffer.sizes` back to `static readonly` now that tests are clearing it rather than setting it to a new dictionary.
- Add locking to `FileLog.ChangeIndent` - for consistency with other side-effecting methods here.