### PR TITLE
FieldRef now supports F = underlying integral type for enum field types

### DIFF
--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -1378,16 +1378,25 @@ namespace HarmonyLib
 
 		static void ValidateFieldType<F>(FieldInfo fieldInfo)
 		{
+			var returnType = typeof(F);
 			var fieldType = fieldInfo.FieldType;
-			if (fieldType.IsValueType)
+			if (returnType == fieldType)
+				return;
+			if (fieldType.IsEnum)
+			{
+				var underlyingType = Enum.GetUnderlyingType(fieldType);
+				if (returnType != underlyingType)
+					throw new ArgumentException("FieldRefAccess return type must be the same as FieldType or " +
+						$"FieldType's underlying integral type ({underlyingType}) for enum types");
+			}
+			else if (fieldType.IsValueType)
 			{
 				// Boxing/unboxing is not allowed for ref values of value types.
-				if (typeof(F) != fieldType)
-					throw new ArgumentException("FieldRefAccess return type must be the same as FieldType for value types");
+				throw new ArgumentException("FieldRefAccess return type must be the same as FieldType for value types");
 			}
 			else
 			{
-				if (typeof(F).IsAssignableFrom(fieldType) is false)
+				if (returnType.IsAssignableFrom(fieldType) is false)
 					throw new ArgumentException("FieldRefAccess return type must be assignable from FieldType for reference types");
 			}
 		}

--- a/HarmonyTests/Tools/Assets/AccessToolsClass.cs
+++ b/HarmonyTests/Tools/Assets/AccessToolsClass.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using System;
 using System.Collections.Generic;
 
 namespace HarmonyLibTests.Assets
@@ -58,6 +59,7 @@ namespace HarmonyLibTests.Assets
 		private Inner[] field6 = new Inner[] { new Inner { x = 11 }, new Inner { x = 22 } };
 		private InnerStruct field7 = new InnerStruct { x = 999 };
 		private List<InnerStruct> field8 = new List<InnerStruct> { new InnerStruct { x = 11 }, new InnerStruct { x = 22 } };
+		internal DayOfWeek field9 = DayOfWeek.Saturday;
 
 		private int _property = 314159;
 
@@ -119,10 +121,23 @@ namespace HarmonyLibTests.Assets
 
 	public struct AccessToolsStruct : IAccessToolsType
 	{
+		private enum InnerEnum : byte
+		{
+			A = 1,
+			B = 2,
+			C = 4,
+		}
+
+		public static Enum NewInnerEnum(byte b)
+		{
+			return (InnerEnum)b;
+		}
+
 		public string structField1;
 		private readonly int structField2;
 		private static int structField3 = -123;
 		public static readonly string structField4 = "structField4orig";
+		private InnerEnum structField5;
 
 		public int Property1 { get; set; }
 
@@ -141,6 +156,7 @@ namespace HarmonyLibTests.Assets
 		{
 			structField1 = "structField1orig";
 			structField2 = -666;
+			structField5 = InnerEnum.B;
 			Property1 = 161803;
 			Property2 = "1.61803";
 		}


### PR DESCRIPTION
`FieldRef` now supports `F` = underlying integral type for `enum` field types