### PR TITLE
AccessTools.CreateInstance improvements

### DIFF
--- a/Harmony/Public/CodeInstruction.cs
+++ b/Harmony/Public/CodeInstruction.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -11,7 +11,7 @@ namespace HarmonyLib
 	public class CodeInstruction
 	{
 		/// <summary>The opcode</summary>
-		/// 
+		///
 		public OpCode opcode;
 
 		/// <summary>The operand</summary>
@@ -19,12 +19,17 @@ namespace HarmonyLib
 		public object operand;
 
 		/// <summary>All labels defined on this instruction</summary>
-		/// 
+		///
 		public List<Label> labels = new List<Label>();
 
 		/// <summary>All exception block boundaries defined on this instruction</summary>
-		/// 
+		///
 		public List<ExceptionBlock> blocks = new List<ExceptionBlock>();
+
+		// Internal parameterless constructor that AccessTools.CreateInstance can use, ensuring that labels/blocks are initialized.
+		internal CodeInstruction()
+		{
+		}
 
 		/// <summary>Creates a new CodeInstruction with a given opcode and optional operand</summary>
 		/// <param name="opcode">The opcode</param>

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -1698,6 +1698,19 @@ namespace HarmonyLib
 			return FormatterServices.GetUninitializedObject(type);
 		}
 
+		/// <summary>Creates an (possibly uninitialized) instance of a given type</summary>
+		/// <typeparam name="T">The class/type</typeparam>
+		/// <returns>The new instance</returns>
+		///
+		public static T CreateInstance<T>()
+		{
+			var instance = CreateInstance(typeof(T));
+			// Not using `as` operator since it only works with reference types.
+			if (instance is T typedInstance)
+				return typedInstance;
+			return default;
+		}
+
 		/// <summary>
 		/// A cache for the <see cref="ICollection{T}.Add"/> or similar Add methods for different types.
 		/// </summary>
@@ -1706,7 +1719,7 @@ namespace HarmonyLib
 		static readonly ReaderWriterLockSlim addHandlerCacheLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
 		/// <summary>Makes a deep copy of any object</summary>
-		/// <typeparam name="T">The type of the instance that should be created</typeparam>
+		/// <typeparam name="T">The type of the instance that should be created; for legacy reasons, this must be a class or interface</typeparam>
 		/// <param name="source">The original object</param>
 		/// <returns>A copy of the original object but of type T</returns>
 		///

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -1692,9 +1692,10 @@ namespace HarmonyLib
 		{
 			if (type is null)
 				throw new ArgumentNullException(nameof(type));
-			var ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, CallingConventions.Any, new Type[0], null);
+			var ctor = type.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, binder: null,
+				CallingConventions.Any, new Type[0], modifiers: null);
 			if (ctor is object)
-				return Activator.CreateInstance(type);
+				return ctor.Invoke(null);
 			return FormatterServices.GetUninitializedObject(type);
 		}
 

--- a/HarmonyTests/Tools/Assets/AccessToolsClass.cs
+++ b/HarmonyTests/Tools/Assets/AccessToolsClass.cs
@@ -168,6 +168,43 @@ namespace HarmonyLibTests.Assets
 	}
 #pragma warning restore CS0169, CS0414, IDE0044, IDE0051, IDE0052
 
+	public static class AccessToolsCreateInstance
+	{
+		// Has default public parameterless constructor.
+		public class NoConstructor
+		{
+			public bool constructorCalled = true;
+		}
+
+		// Does NOT have a default public parameterless constructor (or any parameterless constructor for that matter).
+		public class OnlyNonParameterlessConstructor
+		{
+			public bool constructorCalled = true;
+
+			public OnlyNonParameterlessConstructor(int _)
+			{
+			}
+		}
+
+		public class PublicParameterlessConstructor
+		{
+			public bool constructorCalled = true;
+
+			public PublicParameterlessConstructor()
+			{
+			}
+		}
+
+		public class InternalParameterlessConstructor
+		{
+			public bool constructorCalled = true;
+
+			internal InternalParameterlessConstructor()
+			{
+			}
+		}
+	}
+
 	public static class AccessToolsMethodDelegate
 	{
 		public interface IInterface

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -365,10 +365,10 @@ namespace HarmonyLibTests.Tools
 			Assert.IsTrue(AccessTools.CreateInstance<AccessToolsCreateInstance.NoConstructor>().constructorCalled);
 			Assert.IsFalse(AccessTools.CreateInstance<AccessToolsCreateInstance.OnlyNonParameterlessConstructor>().constructorCalled);
 			Assert.IsTrue(AccessTools.CreateInstance<AccessToolsCreateInstance.PublicParameterlessConstructor>().constructorCalled);
-			Assert.IsFalse(AccessTools.CreateInstance<AccessToolsCreateInstance.InternalParameterlessConstructor>().constructorCalled);
+			Assert.IsTrue(AccessTools.CreateInstance<AccessToolsCreateInstance.InternalParameterlessConstructor>().constructorCalled);
 			var instruction = AccessTools.CreateInstance<CodeInstruction>();
-			Assert.Null(instruction.labels);
-			Assert.Null(instruction.blocks);
+			Assert.NotNull(instruction.labels);
+			Assert.NotNull(instruction.blocks);
 		}
 
 		[Test]

--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -360,6 +360,18 @@ namespace HarmonyLibTests.Tools
 		}
 
 		[Test]
+		public void Test_AccessTools_CreateInstance()
+		{
+			Assert.IsTrue(AccessTools.CreateInstance<AccessToolsCreateInstance.NoConstructor>().constructorCalled);
+			Assert.IsFalse(AccessTools.CreateInstance<AccessToolsCreateInstance.OnlyNonParameterlessConstructor>().constructorCalled);
+			Assert.IsTrue(AccessTools.CreateInstance<AccessToolsCreateInstance.PublicParameterlessConstructor>().constructorCalled);
+			Assert.IsFalse(AccessTools.CreateInstance<AccessToolsCreateInstance.InternalParameterlessConstructor>().constructorCalled);
+			var instruction = AccessTools.CreateInstance<CodeInstruction>();
+			Assert.Null(instruction.labels);
+			Assert.Null(instruction.blocks);
+		}
+
+		[Test]
 		public void Test_AccessTools_TypeExtension_Description()
 		{
 			var types = new Type[] { typeof(string), typeof(int), null, typeof(void), typeof(Test_AccessTools) };


### PR DESCRIPTION
Look at each commit separately.

First commit:
* Add `AccessTools.CreateInstance<T>()`
* Add unit tests that demonstrate `AccessTools.CreateInstance` currently only calls public parameterless constructors

Second commit:
* `AccessTools.CreateInstance` can now use non-public parameterless constructors
* Define internal `CodeInstruction` parameterless constructor
* `AccessTools.CreateInstance` also now invokes the `ConstructorInfo` rather than using `Activator.CreateInstance`; the former should be faster