### PR TITLE
Provide contravariance on FieldRef delegate

### DIFF
--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -836,7 +836,7 @@ namespace HarmonyLib
 		/// </para>
 		/// </remarks>
 		///
-		public delegate ref F FieldRef<T, F>(T instance = default);
+		public delegate ref F FieldRef<in T, F>(T instance = default);
 
 		/// <summary>Creates a field reference delegate for an instance field of a class</summary>
 		/// <typeparam name="T">The class that defines the instance field, or derived class of this type</typeparam>


### PR DESCRIPTION
I'm not 100% sure, but seems like ABI compat is preserved.

Testing out an app that was compiled against a older version of a lib with no contravariance, then running it against a newer version with added contravariance seems to work.