### PR TITLE
Bugfix priority attribute

### DIFF
--- a/Harmony/Public/HarmonyMethod.cs
+++ b/Harmony/Public/HarmonyMethod.cs
@@ -139,7 +139,10 @@ namespace HarmonyLib
 				HarmonyFields().ForEach(f =>
 				{
 					var val = trv.Field(f).GetValue();
-					if (val is object)
+					// The second half of this if is needed because priority defaults to -1
+					// This causes the value of a HarmonyPriority attribute to be overriden by the next attribute if it is not merged last
+					// should be removed by making priority nullable and default to null at some point
+					if (val is object && (f != nameof(HarmonyMethod.priority) || (int)val != -1))
 						HarmonyMethodExtensions.SetValue(resultTrv, f, val);
 				});
 			});
@@ -232,7 +235,11 @@ namespace HarmonyLib
 			{
 				var baseValue = masterTrv.Field(f).GetValue();
 				var detailValue = detailTrv.Field(f).GetValue();
-				SetValue(resultTrv, f, detailValue ?? baseValue);
+				// This if is needed because priority defaults to -1
+				// This causes the value of a HarmonyPriority attribute to be overriden by the next attribute if it is not merged last
+				// should be removed by making priority nullable and default to null at some point
+				if (f != nameof(HarmonyMethod.priority) || (int)detailValue != -1)
+					SetValue(resultTrv, f, detailValue ?? baseValue);
 			});
 			return result;
 		}

--- a/HarmonyTests/Tools/Assets/AttributesClass.cs
+++ b/HarmonyTests/Tools/Assets/AttributesClass.cs
@@ -14,6 +14,7 @@ namespace HarmonyLibTests.Assets
 
 	[HarmonyPatch(typeof(string))]
 	[HarmonyPatch("foobar")]
+	[HarmonyPriority(Priority.High)]
 	[HarmonyPatch(new Type[] { typeof(float), typeof(string) })]
 	public class AllAttributesClass
 	{

--- a/HarmonyTests/Tools/TestAttributes.cs
+++ b/HarmonyTests/Tools/TestAttributes.cs
@@ -20,6 +20,7 @@ namespace HarmonyLibTests.Tools
 			Assert.AreEqual(2, info.argumentTypes.Length);
 			Assert.AreEqual(typeof(float), info.argumentTypes[0]);
 			Assert.AreEqual(typeof(string), info.argumentTypes[1]);
+			Assert.AreEqual(Priority.High, info.priority);
 		}
 
 		[Test]


### PR DESCRIPTION
When the HarmonyMethods for attributes are merged, Harmony considers that if the detail attribute field has a null value, it shouldn't be applied. This doesn't consider that the priority field defaults to -1, and causes it to be overridden if the HarmonyPriority attribute isn't merged last.

This is shown with 0b5867c32e23df54393a9d7ade907fe9da2f310b, which fails without the second commit also applied.

I think the proper solution would be to make priority a nullable int so it is caught by the existing if statements, but I *believe* this breaks API compat? Adding an exception to the ifs seemed like a safer option, so this PR does that instead.