### PR TITLE
Fixes HarmonySharedState:GetOriginal  

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<MonoModCommonVersion>21.6.21.1</MonoModCommonVersion>
+		<MonoModCommonVersion>21.7.13.2</MonoModCommonVersion>
 	</PropertyGroup>
 
 </Project>

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -244,8 +244,6 @@ namespace HarmonyLib
 		public static MethodBase GetMethodFromStackframe(StackFrame frame)
 		{
 			if (frame == null) throw new ArgumentNullException(nameof(frame));
-			var method = frame.GetMethod();
-			if (method != null) return method;
 			return HarmonySharedState.FindReplacement(frame);
 		}
 

--- a/HarmonyTests/Extras/RetrieveOriginalMethod.cs
+++ b/HarmonyTests/Extras/RetrieveOriginalMethod.cs
@@ -1,0 +1,49 @@
+using HarmonyLib;
+using NUnit.Framework;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace HarmonyLibTests.Extras
+{
+	[TestFixture]
+	class RetrieveOriginalMethod : TestLogger
+	{
+		[Test]
+		public void Test0()
+		{
+			var harmony = new Harmony("test-original-method");
+
+			var originalMethod = AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(RetrieveOriginalMethod.PatchTarget));
+			var dummyPrefix = AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(RetrieveOriginalMethod.DummyPrefix));
+
+			_ = harmony.Patch(originalMethod, new HarmonyMethod(dummyPrefix));
+
+			PatchTarget();
+		}
+
+		private static void ChecksStackTrace()
+		{
+			var st = new StackTrace(1, false);
+			var method = Harmony.GetMethodFromStackframe(st.GetFrame(0));
+
+			// Replacement will be HarmonyLibTests.Extras.RetrieveOriginalMethod.PatchTarget_Patch1
+			// We should be able to go from this method, back to HarmonyLibTests.Extras.PatchTarget
+			if (method is MethodInfo replacement)
+			{
+				var original = Harmony.GetOriginalMethod(replacement);
+				Assert.NotNull(original);
+				Assert.Equals(original, AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(RetrieveOriginalMethod.PatchTarget)));
+			}
+		}
+
+		internal static void PatchTarget()
+		{
+			ChecksStackTrace();
+		}
+
+		internal static void DummyPrefix()
+		{
+
+		}
+	}
+}

--- a/HarmonyTests/Extras/RetrieveOriginalMethod.cs
+++ b/HarmonyTests/Extras/RetrieveOriginalMethod.cs
@@ -32,7 +32,7 @@ namespace HarmonyLibTests.Extras
 			{
 				var original = Harmony.GetOriginalMethod(replacement);
 				Assert.NotNull(original);
-				Assert.Equals(original, AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(RetrieveOriginalMethod.PatchTarget)));
+				Assert.AreEqual(original, AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(RetrieveOriginalMethod.PatchTarget)));
 			}
 		}
 


### PR DESCRIPTION
Adds a unit test demonstrating, and then fixes a bug where the `MethodInfo` reference returned from a StackTrace is not equivalent to the reference which gets returned from `HarmonyLib.MethodPatcher:CreateReplacement`.

This relies on an update from MonoMod.Common which attempts to source the original method from method which is returned from the stack trace. This can then be used to find the pointer which represents the start of the method, which can be used to identify which original method it is referring to.

Let me know if you would like me to squash changes into a single commit, or clean up any details of the implementation.