### PR TITLE
Update MonoMod, add FixReflectionCacheAuto calls

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<MonoModCommonVersion>21.6.21.1</MonoModCommonVersion>
+		<MonoModCommonVersion>21.7.22.3</MonoModCommonVersion>
 	</PropertyGroup>
 
 </Project>

--- a/Harmony/Internal/MethodCopier.cs
+++ b/Harmony/Internal/MethodCopier.cs
@@ -554,6 +554,7 @@ namespace HarmonyLib
 				{
 					var val = ilBytes.ReadInt32();
 					instruction.operand = module.ResolveMember(val, typeArguments, methodArguments);
+					((MemberInfo)instruction.operand).DeclaringType?.FixReflectionCacheAuto();
 					GetMemberInfoValue((MemberInfo)instruction.operand, out instruction.argument);
 					break;
 				}
@@ -562,6 +563,7 @@ namespace HarmonyLib
 				{
 					var val = ilBytes.ReadInt32();
 					instruction.operand = module.ResolveType(val, typeArguments, methodArguments);
+					((Type)instruction.operand).FixReflectionCacheAuto();
 					instruction.argument = (Type)instruction.operand;
 					break;
 				}
@@ -570,6 +572,7 @@ namespace HarmonyLib
 				{
 					var val = ilBytes.ReadInt32();
 					instruction.operand = module.ResolveMethod(val, typeArguments, methodArguments);
+					((MemberInfo)instruction.operand).DeclaringType?.FixReflectionCacheAuto();
 					if (instruction.operand is ConstructorInfo)
 						instruction.argument = (ConstructorInfo)instruction.operand;
 					else
@@ -581,6 +584,7 @@ namespace HarmonyLib
 				{
 					var val = ilBytes.ReadInt32();
 					instruction.operand = module.ResolveField(val, typeArguments, methodArguments);
+					((MemberInfo)instruction.operand).DeclaringType?.FixReflectionCacheAuto();
 					instruction.argument = (FieldInfo)instruction.operand;
 					break;
 				}


### PR DESCRIPTION
This PR updates MonoMod.Common and adds calls to the new `FixReflectionCacheAuto` method where necessary.

Please see [this Stardew Valley Modding API issue comment](https://github.com/Pathoschild/SMAPI/issues/722#issuecomment-880239368) for more information.  
TL;DR is that the XNA Framework depends on the order of `type.GetFields()` to stay consistent (even MSDN says to *not* do so!), but calling `ResolveField` (and also possibly other member-resolving methods) changes the order that the .NET Framework caches for subsequent calls.  
**This was also a problem with Harmony 1.X**, but it was merely avoided by the fact that the XNA Framework was the first thing to call `.GetFields()` on the affected type *before* the "incorrect" order got cached. Pathoschild confirmed experimentally that patching a method in `type` with Harmony 1.X and then calling `type.GetFields()` before XNA gets to do replicates the issue in the comment linked above, and I was able to verify the `.GetFields()` "malfunction" locally as well.

`FixReflectionCacheAuto` fixes the reflection cache where necessary by ordering all serialization-relevant members by their metadata token (effectively by declaration / compilation order), which matches the previous behavior and matches what XNA (and probably other reflection-using libraries) expect.

In a perfect world, XNA and anything else using `GetFields()` and other reflection APIs with ambiguous orders would sort the returned array themselves, but patching the affected callers in XNA is hard (thanks, generics) and I preferred having a general purpose fix, even if it means impacting performance minimally in some circumstances.