### PR TITLE
Fix issue #414: add a sacrificial JIT trampoline after short methods

### DIFF
--- a/Harmony/Internal/Memory.cs
+++ b/Harmony/Internal/Memory.cs
@@ -100,7 +100,9 @@ namespace HarmonyLib
 
 			var methodDef = new DynamicMethodDefinition($"PadMethod-{Guid.NewGuid()}", typeof(void), new Type[0]);
 			methodDef.GetILGenerator().Emit(OpCodes.Ret);
-			_ = GetMethodStart(methodDef.Generate(), out var _); // trigger allocation/generation of jitted assembler
+			// Invoke the method so that it generates a trampoline that will later get overridden by the detour
+			// code.
+			methodDef.Generate().Invoke(null, null);
 		}
 
 		/// <summary>Writes a jump to memory</summary>


### PR DESCRIPTION
The previous attempt to fix the short method issue was allocating memory
from a dynamic code manager. However, the detour was overwriting memory
inside the global code manager.

This fix calls the dynamically generated padding method, which forces
Mono to allocate a JIT trampoline for the padding method. Even though
the padding function is stored in a dynamic code manager, the JIT
trampoline is allocated from the global code manager. Shortly
afterwards, patching the short function will overwrite the padding
method's JIT trampoline, instead of the next important thing that is
stored in the global code manager.