### PR TITLE
Support for `JsonSerialization` where `BinaryFormatter` is not supported in .NET 5.0+

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -27,6 +27,20 @@
 		<DefaultItemExcludes>$(DefaultItemExcludes);Documentation/**</DefaultItemExcludes>
 	</PropertyGroup>
 
+	<!-- In .NET 5.0 Binary Formatters are off by default.  Support is added for .NET 5.0+ for fallback JSON Serialization -->
+	<Choose>
+		<When Condition="'$(TargetFramework)' == 'net5.0'">
+			<PropertyGroup>
+				<IsNET5OrGreater>true</IsNET5OrGreater>
+			</PropertyGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<IsNET5OrGreater>false</IsNET5OrGreater>
+			</PropertyGroup>
+		</Otherwise>
+	</Choose>
+
 	<Choose>
 		<!--
 		Ideally would check for .NET Core and .NET 5.0+ via TargetFrameworkIdentifier being .NETCoreApp, but that property isn't defined at this point,
@@ -94,8 +108,8 @@
 		<DebugSymbols>false</DebugSymbols>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="$(IsCoreOrStandard)">
-		<DefineConstants>$(DefineConstants);CORE_OR_STANDARD</DefineConstants>
+	<PropertyGroup Condition="$(IsNET5OrGreater)">
+		<DefineConstants>$(DefineConstants);NET50_OR_GREATER</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -115,8 +129,11 @@
 		<PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.14" PrivateAssets="all" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(IsCoreOrStandard)">
+	<ItemGroup Condition="$(IsNET5OrGreater)">
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />
+	</ItemGroup>
+	<ItemGroup Condition="!$(IsNET5OrGreater)">
+		<Compile Remove="**\*.net5.cs" />
 	</ItemGroup>
 
 	<!--

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -94,6 +94,10 @@
 		<DebugSymbols>false</DebugSymbols>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(IsCoreOrStandard)">
+		<DefineConstants>$(DefineConstants);CORE_OR_STANDARD</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- https://dev.azure.com/MonoMod/MonoMod/_packaging?_a=feed&feed=DevBuilds -->
 		<PackageReference Include="MonoMod.Common" Version="$(MonoModCommonVersion)">
@@ -109,6 +113,10 @@
 		WE MUST USE VERSION 2.1.14 HERE FOR NOW!
 		-->
 		<PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.14" PrivateAssets="all" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(IsCoreOrStandard)">
+		<PackageReference Include="System.Text.Json" Version="5.0.2" />
 	</ItemGroup>
 
 	<!--

--- a/Harmony/Public/Patch.cs
+++ b/Harmony/Public/Patch.cs
@@ -18,14 +18,22 @@ namespace HarmonyLib
 	internal static class PatchInfoSerialization
 	{
 #if NET50_OR_GREATER
+		static bool? _useBinaryFormatter = null;
 		static bool useBinaryFormatter
 		{
 			get
 			{
-				// https://github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/LocalAppContextSwitches.cs#L14
-				bool hasSwitch = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled);
-				// Default true - https://github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/Common/src/System/LocalAppContextSwitches.Common.cs#L54
-				return (hasSwitch) ? isEnabled : true;
+				if(!_useBinaryFormatter.HasValue)
+				{
+					// https://github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/LocalAppContextSwitches.cs#L14
+					bool hasSwitch = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled);
+					if(hasSwitch)
+						_useBinaryFormatter = isEnabled;
+					else
+						_useBinaryFormatter = true; // Default true, inline with Microsoft - https://github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/Common/src/System/LocalAppContextSwitches.Common.cs#L54
+				}
+
+				return _useBinaryFormatter.Value;
 			}
 		}
 #endif

--- a/Harmony/Public/Patch.cs
+++ b/Harmony/Public/Patch.cs
@@ -58,7 +58,6 @@ namespace HarmonyLib
 		{
 			// ! https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide
 #if CORE_OR_STANDARD
-			var test = JsonSerializer.Serialize<PatchInfo>(patchInfo, _defaultJsonSerializerOptions);
 			return JsonSerializer.SerializeToUtf8Bytes<PatchInfo>(patchInfo, _defaultJsonSerializerOptions);
 #else
 			using var streamMemory = new MemoryStream();

--- a/Harmony/Public/PatchJsonConverter.net5.cs
+++ b/Harmony/Public/PatchJsonConverter.net5.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace HarmonyLib
+{
+	internal class PatchJsonConverter : JsonConverter<Patch>
+	{
+		public override Patch Read(
+				ref Utf8JsonReader reader,
+				Type typeToConvert,
+				JsonSerializerOptions options)
+		{
+			if(reader.TokenType != JsonTokenType.StartObject)
+			{
+				throw new JsonException();
+			}
+
+			reader.SkipPropertyName(); // index
+			int index = reader.GetInt32();
+			reader.SkipPropertyName(); // debug
+			bool debug = reader.GetBoolean();
+			reader.SkipPropertyName(); // owner
+			string owner = reader.GetString();
+			reader.SkipPropertyName(); // priority
+			int priority = reader.GetInt32();
+			reader.SkipPropertyName(); // methodToken
+			int methodToken = reader.GetInt32();
+			reader.SkipPropertyName(); // moduleGUID
+			string moduleGUID = reader.GetString();
+			reader.SkipPropertyName(); // after
+			List<string> after = reader.GetStringArray();
+			reader.SkipPropertyName(); // before
+			List<string> before = reader.GetStringArray();
+
+			return new Patch(index, owner, priority, before.ToArray(), after.ToArray(), debug, methodToken, moduleGUID);
+		}
+
+		public override void Write(
+			 Utf8JsonWriter writer,
+			 Patch patchValue,
+			 JsonSerializerOptions options)
+		{
+			writer.WriteStartObject();
+			writer.WriteNumber("index", patchValue.index);
+			writer.WriteBoolean("debug", patchValue.debug);
+			writer.WriteString("owner", patchValue.owner);
+			writer.WriteNumber("priority", patchValue.priority);
+			writer.WriteNumber("methodToken", patchValue.PatchMethod.MetadataToken);
+			writer.WriteString("moduleGUID", patchValue.PatchMethod.Module.ModuleVersionId.ToString());
+			writer.WriteStringArray("after", patchValue.after);
+			writer.WriteStringArray("before", patchValue.before);
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/Harmony/Public/PatchJsonConverter.net5.cs
+++ b/Harmony/Public/PatchJsonConverter.net5.cs
@@ -7,15 +7,10 @@ namespace HarmonyLib
 {
 	internal class PatchJsonConverter : JsonConverter<Patch>
 	{
-		public override Patch Read(
-				ref Utf8JsonReader reader,
-				Type typeToConvert,
-				JsonSerializerOptions options)
+		public override Patch Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 		{
 			if(reader.TokenType != JsonTokenType.StartObject)
-			{
 				throw new JsonException();
-			}
 
 			reader.SkipPropertyName(); // index
 			int index = reader.GetInt32();
@@ -37,10 +32,7 @@ namespace HarmonyLib
 			return new Patch(index, owner, priority, before.ToArray(), after.ToArray(), debug, methodToken, moduleGUID);
 		}
 
-		public override void Write(
-			 Utf8JsonWriter writer,
-			 Patch patchValue,
-			 JsonSerializerOptions options)
+		public override void Write(Utf8JsonWriter writer, Patch patchValue, JsonSerializerOptions options)
 		{
 			writer.WriteStartObject();
 			writer.WriteNumber("index", patchValue.index);

--- a/Harmony/Public/UtfJsonReaderExtensions.net5.cs
+++ b/Harmony/Public/UtfJsonReaderExtensions.net5.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace HarmonyLib
+{
+	internal static class Utf8JsonReaderExtensions
+	{
+		internal static void SkipPropertyName(this Utf8JsonReader reader)
+		{
+			reader.Read(); //this is the `PropertyName`, skip it
+			reader.Read(); //this is the `value`, making it ready to get
+		}
+
+		internal static void WriteStringArray(this Utf8JsonWriter writer, string propertyName, IEnumerable<string> array)
+		{
+			writer.WriteStartArray(propertyName);
+			foreach(var a in array)
+				writer.WriteStringValue(a);
+			writer.WriteEndArray();
+		}
+
+		internal static List<string> GetStringArray(this Utf8JsonReader reader)
+		{
+			List<string> data = new List<string>();
+			while(reader.Read())
+			{
+				if(reader.TokenType == JsonTokenType.EndArray)
+					break;
+				data.Add(reader.GetString());
+			}
+			return data;
+		}
+	}
+}

--- a/Harmony/Public/UtfJsonReaderExtensions.net5.cs
+++ b/Harmony/Public/UtfJsonReaderExtensions.net5.cs
@@ -7,28 +7,24 @@ namespace HarmonyLib
 	{
 		internal static void SkipPropertyName(this Utf8JsonReader reader)
 		{
-			reader.Read(); //this is the `PropertyName`, skip it
-			reader.Read(); //this is the `value`, making it ready to get
+			reader.Read(); // this is the `PropertyName`, skip it
+			reader.Read(); // this is the `value`, making it ready to get
 		}
 
-		internal static void WriteStringArray(this Utf8JsonWriter writer, string propertyName, IEnumerable<string> array)
+		internal static void WriteStringArray(this Utf8JsonWriter writer, string propertyName, IEnumerable<string> strings)
 		{
 			writer.WriteStartArray(propertyName);
-			foreach(var a in array)
-				writer.WriteStringValue(a);
+			foreach(var str in strings)
+				writer.WriteStringValue(str);
 			writer.WriteEndArray();
 		}
 
 		internal static List<string> GetStringArray(this Utf8JsonReader reader)
 		{
-			List<string> data = new List<string>();
-			while(reader.Read())
-			{
-				if(reader.TokenType == JsonTokenType.EndArray)
-					break;
-				data.Add(reader.GetString());
-			}
-			return data;
+			List<string> strings = new List<string>();
+			while(reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+				strings.Add(reader.GetString());
+			return strings;
 		}
 	}
 }

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -24,6 +24,10 @@
 		<DebugSymbols>false</DebugSymbols>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(TargetFramework.Contains('.'))">
+		<DefineConstants>$(DefineConstants);CORE_OR_STANDARD</DefineConstants>
+	</PropertyGroup>
+
 	<!-- Workaround for `dotnet test HarmonyTests -f net35` not running tests - Microsoft.NET.Test.Sdk only sets IsTestProject property for net40+. -->
 	<PropertyGroup Condition="'$(TargetFramework)'=='net35'">
 		<IsTestProject>true</IsTestProject>

--- a/HarmonyTests/HarmonyTests.csproj
+++ b/HarmonyTests/HarmonyTests.csproj
@@ -24,10 +24,6 @@
 		<DebugSymbols>false</DebugSymbols>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="$(TargetFramework.Contains('.'))">
-		<DefineConstants>$(DefineConstants);CORE_OR_STANDARD</DefineConstants>
-	</PropertyGroup>
-
 	<!-- Workaround for `dotnet test HarmonyTests -f net35` not running tests - Microsoft.NET.Test.Sdk only sets IsTestProject property for net40+. -->
 	<PropertyGroup Condition="'$(TargetFramework)'=='net35'">
 		<IsTestProject>true</IsTestProject>


### PR DESCRIPTION
Starting with I believe .NET 5, `BinaryFormatters` aren't supported by default.  To use them, you have to enable them in your .csproj with the following.
```xml
<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
```

For security reasons, Microsoft is recommending that support for this be removed in applications as outlined here - https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide

The two places I can see this occurring (at least in the project I am using) are in the following methods
https://github.com/pardeike/Harmony/blob/4c6eaed10c3fd5133b8ee5805e1919103ca812ba/Harmony/Public/Patch.cs#L41-L47

https://github.com/pardeike/Harmony/blob/4c6eaed10c3fd5133b8ee5805e1919103ca812ba/Harmony/Public/Patch.cs#L53-L58

Using the recommendations mentioned in that article, I replaced the `BinaryFormatter` logic with `JsonSerializer` in `System.Text.Json`.  It does not serialize it to a JSON string, but rather still keeps it in bytes so that the rest of the logic works exactly as it did before.

To try and ensure backwards compatibility, I added compiler flags so that this change is only present in the following frameworks defined in the `.csproj`.
`netcoreapp3.0;netcoreapp3.1;net5.0`

Please let me know if you have any questions or want to discuss this PR more.  Thanks!