### PR TITLE
Fix Regression from #412

### DIFF
--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -244,7 +244,7 @@ namespace HarmonyLib
 		public static MethodBase GetMethodFromStackframe(StackFrame frame)
 		{
 			if (frame == null) throw new ArgumentNullException(nameof(frame));
-			return HarmonySharedState.FindReplacement(frame);
+			return HarmonySharedState.FindReplacement(frame) ?? frame.GetMethod();
 		}
 
 		/// <summary>Gets Harmony version for all active Harmony instances</summary>


### PR DESCRIPTION
Now guarantees that if a method can be found from a stack frame, `GetMethodFromStackframe` will return it.

This fixes the case in `HarmonySharedState.FindReplacement` where `methodStart` is not zero, but frameMethod is also not null. This is the correct behavior for that method, as if harmony can not find a method which has been patched. It should not return anything. However, `GetMethodFromStackframe` should default to what `stackframe.GetMethod()` returns.