### PR TITLE
Prevent Inlining of Test method

### DIFF
--- a/HarmonyTests/Extras/RetrieveOriginalMethod.cs
+++ b/HarmonyTests/Extras/RetrieveOriginalMethod.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using NUnit.Framework;
+using System;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -36,7 +37,12 @@ namespace HarmonyLibTests.Extras
 
 		internal static void PatchTarget()
 		{
-			ChecksStackTrace(); // call this from within PatchTarget
+			try {
+				ChecksStackTrace(); // call this from within PatchTarget
+				throw new Exception();
+			} catch (Exception e) {
+				
+			}
 		}
 
 		// [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Fixes the failing tests on .NET 5 / core standard 1/2. These compilers obviously have much more aggressive inlining, and the method we are looking for in this particular test case was just completely elided.