### PR TITLE
Improve Performance of `FindReplacement`

### DIFF
--- a/HarmonyTests/Extras/RetrieveOriginalMethod.cs
+++ b/HarmonyTests/Extras/RetrieveOriginalMethod.cs
@@ -9,8 +9,25 @@ namespace HarmonyLibTests.Extras
 	[TestFixture]
 	class RetrieveOriginalMethod : TestLogger
 	{
+		private static void CheckStackTraceFor(MethodBase expectedMethod)
+		{
+			Assert.NotNull(expectedMethod);
+
+			var st = new StackTrace(1, false);
+			var method = Harmony.GetMethodFromStackframe(st.GetFrame(0));
+			
+			Assert.NotNull(method);
+			
+			if (method is MethodInfo replacement)
+			{
+				var original = Harmony.GetOriginalMethod(replacement);
+				Assert.NotNull(original);
+				Assert.AreEqual(original, expectedMethod);
+			}
+		}
+		
 		[Test]
-		public void Test0()
+		public void TestRegularMethod()
 		{
 			var harmony = new Harmony("test-original-method");
 			var originalMethod = SymbolExtensions.GetMethodInfo(() => PatchTarget());
@@ -18,38 +35,47 @@ namespace HarmonyLibTests.Extras
 			_ = harmony.Patch(originalMethod, new HarmonyMethod(dummyPrefix));
 			PatchTarget();
 		}
-
-		private static void ChecksStackTrace()
+		
+		[Test]
+		public void TestConstructor()
 		{
-			var st = new StackTrace(1, false);
-			var method = Harmony.GetMethodFromStackframe(st.GetFrame(0));
-
-			// Replacement will be HarmonyLibTests.Extras.RetrieveOriginalMethod.PatchTarget_Patch1
-			// We should be able to go from this method, back to HarmonyLibTests.Extras.PatchTarget
-			//
-			if (method is MethodInfo replacement)
-			{
-				var original = Harmony.GetOriginalMethod(replacement);
-				Assert.NotNull(original);
-				Assert.AreEqual(original, AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(RetrieveOriginalMethod.PatchTarget)));
-			}
+			var harmony = new Harmony("test-original-method-1");
+			var originalMethod = AccessTools.Constructor(typeof(NestedClass), new Type[] { typeof(int) });
+			var dummyPrefix = SymbolExtensions.GetMethodInfo(() => DummyPrefix());
+			_ = harmony.Patch(originalMethod, new HarmonyMethod(dummyPrefix));
+			var inst = new NestedClass(5);
+			_ = inst.index;
 		}
 
 		internal static void PatchTarget()
 		{
-			try
-			{
-				ChecksStackTrace(); // call this from within PatchTarget
+			try {
+				CheckStackTraceFor(AccessTools.Method(typeof(RetrieveOriginalMethod), nameof(PatchTarget))); // call this from within PatchTarget
 				throw new Exception();
-			}
-			catch
-			{
+			} catch (Exception e) {
+				_ = e;
 			}
 		}
 
 		// [MethodImpl(MethodImplOptions.NoInlining)]
 		internal static void DummyPrefix()
 		{
+		}
+
+		class NestedClass {
+			public NestedClass(int i)
+			{
+				try {
+					CheckStackTraceFor(AccessTools.Constructor(typeof(NestedClass), new Type[] { typeof(int) })); 
+					throw new Exception();
+				} catch (Exception e)
+				{
+					_ = e;
+				}
+				index = i;
+			}
+
+			public int index;
 		}
 	}
 }


### PR DESCRIPTION
I was experimenting with some code which used FindReplacement very frequently (to analyze a large number of heavily modded stack-traces). I noticed that a non trivial amount of time was spent in this method, when it didn't have to.

The two main existing issues are:
1. The actual lookup `.GetNativeStart()` is relatively expensive, and in the average case, is executed on half of the methods that harmony stores, every time someone calls `FindReplacement`.
2. The code, while doing this expensive lookup, was inside a lock used when patching/unpatching etc. 

This is one approach to fixing both issues, solving it by caching the native start of methods inside HarmonySharedState. The locking is subsequently no longer an issue, because the lookup is now significantly faster. 

I also believe this approach is backwards compatible, because we can re-calculate this field from the values inside `originals`. 