### PR TITLE
Removed unneccesary '.ToList().AsEnumerable()' in Harmony/Internal/CodeTranspiler.cs

### DIFF
--- a/Harmony/Internal/CodeTranspiler.cs
+++ b/Harmony/Internal/CodeTranspiler.cs
@@ -17,8 +17,7 @@ namespace HarmonyLib
 		{
 			this.argumentShift = argumentShift;
 			codeInstructions = ilInstructions
-				.Select(ilInstruction => ilInstruction.GetCodeInstruction())
-				.ToList().AsEnumerable();
+				.Select(ilInstruction => ilInstruction.GetCodeInstruction());
 		}
 
 		internal void Add(MethodInfo transpiler)


### PR DESCRIPTION
The output of the '_Select_' method is already of type 'IEnumerable<CodeInstruction>' so enumerating it and then converting back to 'IEnumerable<CodeInstruction>' is **obsolete**.