### PR TITLE
Don't emit stloc ldloc resultVariable in methods ending in throws

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -146,14 +146,14 @@ namespace HarmonyLib
 
 			foreach (var label in endLabels)
 				emitter.MarkLabel(label);
-			if (resultVariable is object)
+			if (resultVariable is object && hasReturnCode)
 				emitter.Emit(OpCodes.Stloc, resultVariable);
 			if (skipOriginalLabel.HasValue)
 				emitter.MarkLabel(skipOriginalLabel.Value);
 
 			_ = AddPostfixes(privateVars, false);
 
-			if (resultVariable is object)
+			if (resultVariable is object && hasReturnCode)
 				emitter.Emit(OpCodes.Ldloc, resultVariable);
 
 			var needsToStorePassthroughResult = AddPostfixes(privateVars, true);


### PR DESCRIPTION
When creating a replacement for methods which end in `throw`s, Harmony currently doesn't check if the method actually ends in a `ret` or `throw` and ends up emitting invalid `stloc`s and `ldloc`s. This PR fixes that.

A good example of the previously invalid IL can be seen in #458. This PR **won't** fix the entirety of #458 though, as this only affects the invalid IL seen there, not compatibility with "protected assemblies" in general.