### PR TITLE
Don't JIT-compile generic methods in FindReplacement

### DIFF
--- a/Harmony/Internal/HarmonySharedState.cs
+++ b/Harmony/Internal/HarmonySharedState.cs
@@ -142,7 +142,7 @@ namespace HarmonyLib
 			var frameMethod = frame.GetMethod();
 			var methodStart = 0L;
 
-			if (frameMethod is null)
+			if (frameMethod is null || frameMethod.IsGenericMethod)
 			{
 				if (methodAddress == null) return null;
 				methodStart = (long)methodAddress.GetValue(frame);


### PR DESCRIPTION
`Harmony.GetMethodFromStackframe` fails hard when encountering generics, as `FindReplacement` tries to JIT-compile and get the native address of an uninstantiated generic.

This PR makes `FindReplacement` check the stack frame's method address if possible for generic methods instead.