### PR TITLE
SymbolExtensions.GetMethodInfo allow parameterless method decoding

### DIFF
--- a/Harmony/Tools/SymbolExtensions.cs
+++ b/Harmony/Tools/SymbolExtensions.cs
@@ -47,7 +47,11 @@ namespace HarmonyLib
 			var outermostExpression = expression.Body as MethodCallExpression;
 
 			if (outermostExpression is null)
+			{
+				if (expression.Body is UnaryExpression ue && ue.Operand is MethodCallExpression me && me.Object is System.Linq.Expressions.ConstantExpression ce && ce.Value is MethodInfo mi)
+					return mi;
 				throw new ArgumentException("Invalid Expression. Expression should consist of a Method call only.");
+			}
 
 			var method = outermostExpression.Method;
 			if (method is null)


### PR DESCRIPTION
Use complex LambdaExpression walking to allow  `GetMethodInfo (() => myMethod)` rather than `GetMethodInfo(() => myMethod(null,null,null....))`

Quality of life improvement.    Right now manual patching is a bit annoying to pass complex method replacements to, especially when you have ref variables as for a method like:

`private static bool prePatchSomething(ref string something, ref bool correct, ref Assembly loaded, ref MyClass __result, String info, int howLong)`
you need to do something like
```
string s1=null;
bool b1=false;
Assembly a1=null;
MyClass m1 = null;
SymbolExtensions.GetMethodInfo(() => prePatchSomething(ref s1, ref b1, ref a1, ref m1, null, 0);
```
With this change:
`SymbolExtensions.GetMethodInfo(prePatchSomething);`

I believe this should be safe.  Might even technically have a bit less overhead but im sure performance difference is negligible either way.