### PR TITLE
Add Categories feature to Patch Container Classes

### DIFF
--- a/Harmony/Documentation/articles/annotations.md
+++ b/Harmony/Documentation/articles/annotations.md
@@ -4,7 +4,9 @@ Instead of writing a lot of reflection code you can use annotations to define yo
 
 To simplify things, each original method you want to patch is usually represented by a "patch class", that is, a class that has at least one harmony patch annotation `[HarmonyPatch]`.
 
-When you call harmony.**PatchAll()**, Harmony will search through all classes and methods inside the given assembly looking for specific Harmony annotations.
+When you call harmony.**PatchAll()**, Harmony will search through all classes and methods inside the given assembly looking for specific Harmony annotations, applying all patch classes that it finds.
+
+To selectively apply certain patch classes, harmony.**PatchCategory()** can be used with `[HarmonyPatchCategory]` to mark specific patch classes to apply. Alongside this, harmony.**PatchAllUncategorized()** can be used to apply patch classes not marked with a specific category. Note that harmony.**PatchAll()** ignores categories.
 
 A typical patch consists of a class with annotations that looks like this:
 
@@ -18,7 +20,7 @@ This example annotates the class with enough information to identify the method 
 
 ##### Limitations
 
-The only limitation is that annotations are not ordered (even if they appear so). At runtime, the order of methdos or multiple annotations on something is undefined. The consequence of this is that you cannot rely on order when you define multiple annotations that theoretically could overwrite each other like with normal inheritance. This normally isn't a problem unless you annotate multiple Prefix methods in a class and expect the order of the prefixes to be as in the source code (use priority annotations in this case).
+The only limitation is that annotations are not ordered (even if they appear so). At runtime, the order of methods or multiple annotations on something is undefined. The consequence of this is that you cannot rely on order when you define multiple annotations that theoretically could overwrite each other like with normal inheritance. This normally isn't a problem unless you annotate multiple Prefix methods in a class and expect the order of the prefixes to be as in the source code (use priority annotations in this case).
 
 ### Annotation alternatives
 
@@ -69,6 +71,13 @@ Basic annotations need to be combined to define all aspects of your original met
 // form allows for a ArgumentType array defining the type of each argument type
 // Normal, Ref, Out or Pointer. Both arrays need to have the same number of elements:
 [HarmonyPatch(Type[] argumentTypes, ArgumentType[] argumentVariations)]
+```
+
+**Category annotation**
+
+```csharp
+// Use with Harmony.PatchCategory()
+[HarmonyPatchCategory(string category)]
 ```
 
 #### Combination annotations

--- a/Harmony/Documentation/articles/basics.md
+++ b/Harmony/Documentation/articles/basics.md
@@ -58,6 +58,8 @@ If you prefer annotations to organize your patches, you instruct Harmony to sear
 
 which will search the given assembly for all classes that are decorated with Harmony annotations. All patches are registered automatically and Harmony will do the rest.
 
+If you need to apply different patches at different times, you can use `PatchCategory()` and the `[HarmonyPatchCategory()]` annotation to exclude them (by default) from `PatchAll()`.
+
 ### Manual patching
 
 For more control, you use `Patch()`. It takes an original and a combination of Prefix, Postfix or Transpiler methods, which are optional HarmonyMethod objects (pass null to `Patch()` to skip one type of patch):

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -106,6 +106,20 @@ namespace HarmonyLib
 		public HarmonyMethod info = new();
 	}
 
+	/// <summary>Annotation to define a category for use with PatchCategory</summary>
+	///
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+	public class HarmonyPatchCategory : HarmonyAttribute
+	{
+		/// <summary>Annotation specifying the category</summary>
+		/// <param name="category">Name of patch category</param>
+		///
+		public HarmonyPatchCategory(string category)
+		{
+			info.category = category;
+		}
+	}
+
 	/// <summary>Annotation to define your Harmony patch methods</summary>
 	///
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate | AttributeTargets.Method, AllowMultiple = true)]

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -116,6 +116,44 @@ namespace HarmonyLib
 			AccessTools.GetTypesFromAssembly(assembly).Do(type => CreateClassProcessor(type).Patch());
 		}
 
+		/// <summary>Searches an assembly for Harmony-annotated classes without category annotations and uses them to create patches</summary>
+		/// 
+		public void PatchAllUncategorized()
+		{
+			var method = new StackTrace().GetFrame(1).GetMethod();
+			var assembly = method.ReflectedType.Assembly;
+			PatchAllUncategorized(assembly);
+		}
+
+		/// <summary>Searches an assembly for Harmony-annotated classes without category annotations and uses them to create patches</summary>
+		/// <param name="assembly">The assembly</param>
+		/// 
+		public void PatchAllUncategorized(Assembly assembly)
+		{
+			PatchClassProcessor[] patchClasses = AccessTools.GetTypesFromAssembly(assembly).Select(CreateClassProcessor).ToArray();
+			patchClasses.DoIf((patchClass => String.IsNullOrEmpty(patchClass.Category)), (patchClass => patchClass.Patch()));
+		}
+
+		/// <summary>Searches an assembly for Harmony annotations with a specific category and uses them to create patches</summary>
+		/// <param name="category">Name of patch category</param>
+		/// 
+		public void PatchCategory(string category)
+		{
+			var method = new StackTrace().GetFrame(1).GetMethod();
+			var assembly = method.ReflectedType.Assembly;
+			PatchCategory(assembly, category);
+		}
+
+		/// <summary>Searches an assembly for Harmony annotations with a specific category and uses them to create patches</summary>
+		/// <param name="assembly">The assembly</param>
+		/// <param name="category">Name of patch category</param>
+		/// 
+		public void PatchCategory(Assembly assembly, string category)
+		{
+			PatchClassProcessor[] patchClasses = AccessTools.GetTypesFromAssembly(assembly).Select(CreateClassProcessor).ToArray();
+			patchClasses.DoIf((patchClass => patchClass.Category == category), (patchClass => patchClass.Patch()));
+		}
+
 		/// <summary>Creates patches by manually specifying the methods</summary>
 		/// <param name="original">The original method/constructor</param>
 		/// <param name="prefix">An optional prefix method wrapped in a <see cref="HarmonyMethod"/> object</param>

--- a/Harmony/Public/HarmonyMethod.cs
+++ b/Harmony/Public/HarmonyMethod.cs
@@ -14,6 +14,10 @@ namespace HarmonyLib
 		/// 
 		public MethodInfo method; // need to be called 'method'
 
+		/// <summary>Patch Category</summary>
+		/// 
+		public string category = null;
+
 		/// <summary>Class/type declaring this patch</summary>
 		/// 
 		public Type declaringType;

--- a/Harmony/Public/PatchClassProcessor.cs
+++ b/Harmony/Public/PatchClassProcessor.cs
@@ -25,6 +25,9 @@ namespace HarmonyLib
 			typeof(HarmonyTargetMethods)
 		};
 
+		/// <summary name="Category">Name of the patch class's category</summary>
+		public string Category { get; set; }
+
 		/// <summary>Creates a patch class processor by pointing out a class. Similar to PatchAll() but without searching through all classes.</summary>
 		/// <param name="instance">The Harmony instance</param>
 		/// <param name="type">The class to process (need to have at least a [HarmonyPatch] attribute)</param>
@@ -46,6 +49,8 @@ namespace HarmonyLib
 			containerAttributes = HarmonyMethod.Merge(harmonyAttributes);
 			if (containerAttributes.methodType is null) // MethodType default is Normal
 				containerAttributes.methodType = MethodType.Normal;
+			
+			this.Category = containerAttributes.category;
 
 			auxilaryMethods = new Dictionary<Type, MethodInfo>();
 			foreach (var auxType in auxilaryTypes)


### PR DESCRIPTION
## Summary
This change adds the following features:

- `[HarmonyPatchCategory(string category)]` attribute, applied to patch container classes to specify one category for a patch
- `Harmony.PatchCategories(string category)` method, called to apply all patch container classes marked with a specific category 
-  `Harmony.PatchAllUncategorized()` method, called to apply any patch container classes not marked with a specific category
- Documentation for the above functionality (in markdown form - not sure if I have to do anything for page generation)

This functionality allows applying different sets of patches at different times when using annotated patch classes. This allows for easy conditional patch application, allowing things like delaying a patch until after a static initializer has run, or performing patches based on user configuration.

## Notes
- For simplicity, `[HarmonyPatchCategory]` can only be applied to patch container classes, not individual patch methods within a container. This avoids having to make a library-level choice about how individual patch method categorization overrides container categorization, which I believe would be an awkward design. Instead, users can control their categorization as needed to create conditional logic for what patches to apply and when.

- Only one category can be applied to a patch. This simplifies the implementation and means that patching multiple different categories will never cause a patch container to be applied more than once.Users can use specific 

- This change does not change the behavior of `Unpatch()` or `UnpatchAll()`. Because of how those methods work, they act based on the methods that were patched, not what patches were used, so it would require extra data to be added to identify what patch categories were used to patch something. Additionally, unpatching seems to unpatch as a whole, so if you only wanted to unpatch a method's patches from one category, it would also unpatch any changes from another category. Future work could maybe change how Unpatching logic is done to allow partial unpatching (or unpatching and re-patching based on categories). 