### PR TITLE
Methods for getting indices and making loads and stores

### DIFF
--- a/Harmony/Public/CodeInstruction.cs
+++ b/Harmony/Public/CodeInstruction.cs
@@ -229,6 +229,80 @@ namespace HarmonyLib
 			return new CodeInstruction(field.IsStatic ? OpCodes.Stsfld : OpCodes.Stfld, field);
 		}
 
+		// --- LOCALS
+
+		/// <summary>Creates a CodeInstruction loading a local with the given index, using the shorter forms when possible</summary>
+		/// <param name="index">The index where the local is stored</param>
+		/// <param name="useAddress">Use address of local</param>
+		/// <returns></returns>
+		/// <seealso cref="CodeInstructionExtensions.LocalIndex(CodeInstruction)"/>
+		public static CodeInstruction LoadLocal(int index, bool useAddress = false)
+		{
+			if (useAddress)
+			{
+				if (index < 256) return new CodeInstruction(OpCodes.Ldloca_S, Convert.ToByte(index));
+				else return new CodeInstruction(OpCodes.Ldloca, index);
+			}
+			else
+			{
+				if (index == 0) return new CodeInstruction(OpCodes.Ldloc_0);
+				else if (index == 1) return new CodeInstruction(OpCodes.Ldloc_1);
+				else if (index == 2) return new CodeInstruction(OpCodes.Ldloc_2);
+				else if (index == 3) return new CodeInstruction(OpCodes.Ldloc_3);
+				else if (index < 256) return new CodeInstruction(OpCodes.Ldloc_S, Convert.ToByte(index));
+				else return new CodeInstruction(OpCodes.Ldloc, index);
+			}
+		}
+
+		/// <summary>Creates a CodeInstruction storing to a local with the given index, using the shorter forms when possible</summary>
+		/// <param name="index">The index where the local is stored</param>
+		/// <returns></returns>
+		/// <seealso cref="CodeInstructionExtensions.LocalIndex(CodeInstruction)"/>
+		public static CodeInstruction StoreLocal(int index)
+		{
+			if (index == 0) return new CodeInstruction(OpCodes.Stloc_0);
+			else if (index == 1) return new CodeInstruction(OpCodes.Stloc_1);
+			else if (index == 2) return new CodeInstruction(OpCodes.Stloc_2);
+			else if (index == 3) return new CodeInstruction(OpCodes.Stloc_3);
+			else if (index < 256) return new CodeInstruction(OpCodes.Stloc_S, Convert.ToByte(index));
+			else return new CodeInstruction(OpCodes.Stloc, index);
+		}
+
+		// --- ARGUMENTS
+
+		/// <summary>Creates a CodeInstruction loading an argument with the given index, using the shorter forms when possible</summary>
+		/// <param name="index">The index of the argument</param>
+		/// <param name="useAddress">Use address of argument</param>
+		/// <returns></returns>
+		/// <seealso cref="CodeInstructionExtensions.ArgIndex(CodeInstruction)"/>
+		public static CodeInstruction LoadArg(int index, bool useAddress = false)
+		{
+			if (useAddress)
+			{
+				if (index < 256) return new CodeInstruction(OpCodes.Ldarga_S, Convert.ToByte(index));
+				else return new CodeInstruction(OpCodes.Ldarga, index);
+			}
+			else
+			{
+				if (index == 0) return new CodeInstruction(OpCodes.Ldarg_0);
+				else if (index == 1) return new CodeInstruction(OpCodes.Ldarg_1);
+				else if (index == 2) return new CodeInstruction(OpCodes.Ldarg_2);
+				else if (index == 3) return new CodeInstruction(OpCodes.Ldarg_3);
+				else if (index < 256) return new CodeInstruction(OpCodes.Ldarg_S, Convert.ToByte(index));
+				else return new CodeInstruction(OpCodes.Ldarg, index);
+			}
+		}
+
+		/// <summary>Creates a CodeInstruction storing to an argument with the given index, using the shorter forms when possible</summary>
+		/// <param name="index">The index of the argument</param>
+		/// <returns></returns>
+		/// <seealso cref="CodeInstructionExtensions.ArgIndex(CodeInstruction)"/>
+		public static CodeInstruction StoreArg(int index)
+		{
+			if (index < 256) return new CodeInstruction(OpCodes.Starg_S, Convert.ToByte(index));
+			else return new CodeInstruction(OpCodes.Starg, index);
+		}
+
 		// --- TOSTRING
 
 		/// <summary>Returns a string representation of the code instruction</summary>

--- a/Harmony/Public/CodeInstruction.cs
+++ b/Harmony/Public/CodeInstruction.cs
@@ -274,8 +274,8 @@ namespace HarmonyLib
 		/// <param name="index">The index of the argument</param>
 		/// <param name="useAddress">Use address of argument</param>
 		/// <returns></returns>
-		/// <seealso cref="CodeInstructionExtensions.ArgIndex(CodeInstruction)"/>
-		public static CodeInstruction LoadArg(int index, bool useAddress = false)
+		/// <seealso cref="CodeInstructionExtensions.ArgumentIndex(CodeInstruction)"/>
+		public static CodeInstruction LoadArgument(int index, bool useAddress = false)
 		{
 			if (useAddress)
 			{
@@ -296,8 +296,8 @@ namespace HarmonyLib
 		/// <summary>Creates a CodeInstruction storing to an argument with the given index, using the shorter forms when possible</summary>
 		/// <param name="index">The index of the argument</param>
 		/// <returns></returns>
-		/// <seealso cref="CodeInstructionExtensions.ArgIndex(CodeInstruction)"/>
-		public static CodeInstruction StoreArg(int index)
+		/// <seealso cref="CodeInstructionExtensions.ArgumentIndex(CodeInstruction)"/>
+		public static CodeInstruction StoreArgument(int index)
 		{
 			if (index < 256) return new CodeInstruction(OpCodes.Starg_S, Convert.ToByte(index));
 			else return new CodeInstruction(OpCodes.Starg, index);

--- a/Harmony/Tools/CodeMatch.cs
+++ b/Harmony/Tools/CodeMatch.cs
@@ -125,6 +125,106 @@ namespace HarmonyLib
 			return true;
 		}
 
+		/// <summary>Creates a code match for local loads</summary>
+		/// <param name="useAddress">Whether to match for address loads</param>
+		/// <param name="name">An optional name</param>
+		/// <returns></returns>
+		public static CodeMatch LoadsLocal(bool useAddress = false, string name = null)
+		{
+			CodeMatch match = new CodeMatch(null, null, name);
+
+			if (useAddress)
+			{
+				match.opcodes.AddRange(new[]
+				{
+					OpCodes.Ldloca_S,
+					OpCodes.Ldloca
+				});
+			}
+			else
+			{
+				match.opcodes.AddRange(new[]
+				{
+					OpCodes.Ldloc_0,
+					OpCodes.Ldloc_1,
+					OpCodes.Ldloc_2,
+					OpCodes.Ldloc_3,
+					OpCodes.Ldloc_S,
+					OpCodes.Ldloc
+				});
+			}
+
+			return match;
+		}
+
+		/// <summary>Creates a code match for local stores</summary>
+		/// <param name="name">An optional name</param>
+		/// <returns></returns>
+		public static CodeMatch StoresLocal(string name = null)
+		{
+			CodeMatch match = new CodeMatch(null, null, name);
+
+			match.opcodes.AddRange(new[]
+			{
+				OpCodes.Stloc_0,
+				OpCodes.Stloc_1,
+				OpCodes.Stloc_2,
+				OpCodes.Stloc_3,
+				OpCodes.Stloc_S,
+				OpCodes.Stloc
+			});
+
+			return match;
+		}
+
+		/// <summary>Creates a code match for argument loads</summary>
+		/// <param name="useAddress">Whether to match for address loads</param>
+		/// <param name="name">An optional name</param>
+		/// <returns></returns>
+		public static CodeMatch LoadsArgument(bool useAddress = false, string name = null)
+		{
+			CodeMatch match = new CodeMatch(null, null, name);
+
+			if (useAddress)
+			{
+				match.opcodes.AddRange(new[]
+				{
+					OpCodes.Ldarga_S,
+					OpCodes.Ldarga
+				});
+			}
+			else
+			{
+				match.opcodes.AddRange(new[]
+				{
+					OpCodes.Ldarg_0,
+					OpCodes.Ldarg_1,
+					OpCodes.Ldarg_2,
+					OpCodes.Ldarg_3,
+					OpCodes.Ldarg_S,
+					OpCodes.Ldarg
+				});
+			}
+
+			return match;
+		}
+
+		/// <summary>Creates a code match for argument stores</summary>
+		/// <param name="name">An optional name</param>
+		/// <returns></returns>
+		public static CodeMatch StoresArgument(string name = null)
+		{
+			CodeMatch match = new CodeMatch(null, null, name);
+
+			match.opcodes.AddRange(new[]
+			{
+				OpCodes.Starg_S,
+				OpCodes.Starg
+			});
+
+			return match;
+		}
+
 		/// <summary>Returns a string that represents the match</summary>
 		/// <returns>A string representation</returns>
 		///

--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -500,9 +500,9 @@ namespace HarmonyLib
 		/// <summary>Returns the index targeted by this <c>ldarg</c>, <c>ldarga</c>, or <c>starg</c></summary>
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <returns>The index it targets</returns>
-		/// <seealso cref="CodeInstruction.LoadArg(int, bool)"/>
-		/// <seealso cref="CodeInstruction.StoreArg(int)"/>
-		public static int ArgIndex(this CodeInstruction code)
+		/// <seealso cref="CodeInstruction.LoadArgument(int, bool)"/>
+		/// <seealso cref="CodeInstruction.StoreArgument(int)"/>
+		public static int ArgumentIndex(this CodeInstruction code)
 		{
 			if (code.opcode == OpCodes.Ldarg_0) return 0;
 			else if (code.opcode == OpCodes.Ldarg_1) return 1;

--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -480,6 +480,40 @@ namespace HarmonyLib
 			return code.opcode == stfldCode && Equals(code.operand, field);
 		}
 
+		/// <summary>Returns the index targeted by this <c>ldloc</c>, <c>ldloca</c>, or <c>stloc</c></summary>
+		/// <param name="code">The <see cref="CodeInstruction"/></param>
+		/// <returns>The index it targets</returns>
+		/// <seealso cref="CodeInstruction.LoadLocal(int, bool)"/>
+		/// <seealso cref="CodeInstruction.StoreLocal(int)"/>
+		public static int LocalIndex(this CodeInstruction code)
+		{
+			if (code.opcode == OpCodes.Ldloc_0 || code.opcode == OpCodes.Stloc_0) return 0;
+			else if (code.opcode == OpCodes.Ldloc_1 || code.opcode == OpCodes.Stloc_1) return 1;
+			else if (code.opcode == OpCodes.Ldloc_2 || code.opcode == OpCodes.Stloc_2) return 2;
+			else if (code.opcode == OpCodes.Ldloc_3 || code.opcode == OpCodes.Stloc_3) return 3;
+			else if (code.opcode == OpCodes.Ldloc_S || code.opcode == OpCodes.Ldloc) return Convert.ToInt32(code.operand);
+			else if (code.opcode == OpCodes.Stloc_S || code.opcode == OpCodes.Stloc) return Convert.ToInt32(code.operand);
+			else if (code.opcode == OpCodes.Ldloca_S || code.opcode == OpCodes.Ldloca) return Convert.ToInt32(code.operand);
+			else throw new ArgumentException("Instruction is not a load or store", "code");
+		}
+
+		/// <summary>Returns the index targeted by this <c>ldarg</c>, <c>ldarga</c>, or <c>starg</c></summary>
+		/// <param name="code">The <see cref="CodeInstruction"/></param>
+		/// <returns>The index it targets</returns>
+		/// <seealso cref="CodeInstruction.LoadArg(int, bool)"/>
+		/// <seealso cref="CodeInstruction.StoreArg(int)"/>
+		public static int ArgIndex(this CodeInstruction code)
+		{
+			if (code.opcode == OpCodes.Ldarg_0) return 0;
+			else if (code.opcode == OpCodes.Ldarg_1) return 1;
+			else if (code.opcode == OpCodes.Ldarg_2) return 2;
+			else if (code.opcode == OpCodes.Ldarg_3) return 3;
+			else if (code.opcode == OpCodes.Ldarg_S || code.opcode == OpCodes.Ldarg) return Convert.ToInt32(code.operand);
+			else if (code.opcode == OpCodes.Starg_S || code.opcode == OpCodes.Starg) return Convert.ToInt32(code.operand);
+			else if (code.opcode == OpCodes.Ldarga_S || code.opcode == OpCodes.Ldarga) return Convert.ToInt32(code.operand);
+			else throw new ArgumentException("Instruction is not a load or store", "code");
+		}
+
 		/// <summary>Adds labels to the code instruction and return it</summary>
 		/// <param name="code">The <see cref="CodeInstruction"/></param>
 		/// <param name="labels">One or several <see cref="Label"/> to add</param>


### PR DESCRIPTION
Adds these extension methods on CodeInstruction:

- LocalIndex, which returns the operand of any ldloc/ldloca/stloc, even the short forms or the fixed forms (i.e. ldloc.s or ldloc.1)

- ArgIndex, which does the same but for ldarg/ldarga/starg

Adds these static helper methods to CodeInstruction:

- LoadLocal, which allows you to produce an optimal load from an index, optionally loading the address

- StoreLocal, which allows you to produce an optional store to an index

- LoadArg, which allows you to produce an optimal load from an argument, optionally loading the address

- StoreArg, which allows you to produce an optimal store to an argument

All of the methods are annotated with doc comments and include links to their counterparts via `<seealso>` references.

Please let me know if I got the names, documentation, or code style (I'm used to OTB) incorrect.