### PR TITLE
Adds support for targeting an async method's internal MoveNext method

### DIFF
--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -87,7 +87,7 @@ namespace HarmonyLib
 						var enumMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
 						return AccessTools.EnumeratorMoveNext(enumMethod);
 
-#if NET40_OR_GREATER
+#if NET45_OR_GREATER
 					case MethodType.Async:
 						if (attr.methodName is null)
 							return null;

--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -84,8 +84,16 @@ namespace HarmonyLib
 					case MethodType.Enumerator:
 						if (attr.methodName is null)
 							return null;
-						var method = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
-						return AccessTools.EnumeratorMoveNext(method);
+						var enumMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
+						return AccessTools.EnumeratorMoveNext(enumMethod);
+
+#if NET40_OR_GREATER
+					case MethodType.Async:
+						if (attr.methodName is null)
+							return null;
+						var asyncMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
+						return AccessTools.AsyncMoveNext(asyncMethod);
+#endif
 				}
 			}
 			catch (AmbiguousMatchException ex)

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -17,10 +17,10 @@ namespace HarmonyLib
 		Constructor,
 		/// <summary>This is a static constructor</summary>
 		StaticConstructor,
-		/// <summary>This targets the MoveNext method of the enumerator result</summary>
+		/// <summary>This targets the MoveNext method of the enumerator result, that actually contains the method's implementation</summary>
 		Enumerator,
-#if NET40_OR_GREATER
-		/// <summary>This targets the MoveNext method of the async state machine</summary>
+#if NET45_OR_GREATER
+		/// <summary>This targets the MoveNext method of the async state machine, that actually contains the method's implementation</summary>
 		Async
 #endif
 	}

--- a/Harmony/Public/Attributes.cs
+++ b/Harmony/Public/Attributes.cs
@@ -18,7 +18,11 @@ namespace HarmonyLib
 		/// <summary>This is a static constructor</summary>
 		StaticConstructor,
 		/// <summary>This targets the MoveNext method of the enumerator result</summary>
-		Enumerator
+		Enumerator,
+#if NET40_OR_GREATER
+		/// <summary>This targets the MoveNext method of the async state machine</summary>
+		Async
+#endif
 	}
 
 	/// <summary>Specifies the type of argument</summary>

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -467,9 +467,9 @@ namespace HarmonyLib
 			return Method(info.type, info.name, parameters, generics);
 		}
 
-		/// <summary>Gets the <see cref="IEnumerator.MoveNext" /> method of an enumerator method</summary>
+		/// <summary>Gets the <see cref="IEnumerator.MoveNext"/> method of an enumerator method</summary>
 		/// <param name="method">Enumerator method that creates the enumerator <see cref="IEnumerator" /></param>
-		/// <returns>The internal <see cref="IEnumerator.MoveNext" /> method of the enumerator or <b>null</b> if no valid enumerator is detected</returns>
+		/// <returns>The internal <see cref="IEnumerator.MoveNext"/> method of the enumerator or <b>null</b> if no valid enumerator is detected</returns>
 		public static MethodInfo EnumeratorMoveNext(MethodBase method)
 		{
 			if (method is null)
@@ -499,10 +499,10 @@ namespace HarmonyLib
 			return Method(type, nameof(IEnumerator.MoveNext));
 		}
 
-#if NET40_OR_GREATER
-		/// <summary>Gets the <see cref="IAsyncStateMachine.MoveNext" /> method of an async method's state machine</summary>
+#if NET45_OR_GREATER
+		/// <summary>Gets the <see cref="IAsyncStateMachine.MoveNext"/> method of an async method's state machine</summary>
 		/// <param name="method">Async method that creates the state machine internally</param>
-		/// <returns>The internal <see cref="IAsyncStateMachine.MoveNext" /> method of the async state machine or <b>null</b> if no valid async method is detected</returns>
+		/// <returns>The internal <see cref="IAsyncStateMachine.MoveNext"/> method of the async state machine or <b>null</b> if no valid async method is detected</returns>
 		public static MethodInfo AsyncMoveNext(MethodBase method)
 		{
 			if (method is null)
@@ -512,15 +512,15 @@ namespace HarmonyLib
 			}
 
 			var asyncAttribute = method.GetCustomAttribute<AsyncStateMachineAttribute>();
-			if (asyncAttribute == null)
+			if (asyncAttribute is null)
 			{
 				FileLog.Debug($"AccessTools.AsyncMoveNext: Could not find AsyncStateMachine for {method.FullDescription()}");
 				return null;
 			}
 
 			var asyncStateMachineType = asyncAttribute.StateMachineType;
-			var asyncMethodBody = DeclaredMethod(asyncStateMachineType, "MoveNext");
-			if (asyncMethodBody == null)
+			var asyncMethodBody = DeclaredMethod(asyncStateMachineType, nameof(IAsyncStateMachine.MoveNext));
+			if (asyncMethodBody is null)
 			{
 				FileLog.Debug($"AccessTools.AsyncMoveNext: Could not find async method body for {method.FullDescription()}");
 				return null;


### PR DESCRIPTION
As the title says. This is particularly interesting for targeting an `async` method with a transpiler, whether using Attributes or manually finding it with the added `AsyncMoveNext` method in AccessTools.

I'm not sure where the tests should go / how they should look, but I did test it on a game that I write mods for.  
Works perfectly, although trying to use `IAsyncStateMachine` as the type for the `__instance` parameter causes a `FormatException` for invalid IL on the call to the patch method (that took a while to figure out).

![Definition of Patches](https://user-images.githubusercontent.com/2124570/222447224-75d7c771-5e0d-4800-bd22-22b6773c4e3c.png)

![Resulting output in log showing all patches are successfully applied](https://user-images.githubusercontent.com/2124570/222447695-18ad222d-81a4-4ddf-8acf-a08beacc50a1.png)
