### PR TITLE
Added netstandard2.0 reference assemblies support

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net35;net452;net472;net48;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net35;net452;net472;net48;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Product>Harmony</Product>
 		<Company>Andreas Pardeike</Company>
@@ -131,6 +131,15 @@
 		WE MUST USE VERSION 2.1.14 HERE FOR NOW!
 		
 		<PackageReference Include="ILRepack.Lib.MSBuild" Version="2.1.14" PrivateAssets="all" /> -->
+	</ItemGroup>
+
+	<!-- netstandard2.0 reference assemblies -->
+	<PropertyGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+		<ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
+	</PropertyGroup>
+	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" PrivateAssets="all" />
+		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(IsNET5OrGreater)">

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -135,12 +135,29 @@
 
 	<!-- netstandard2.0 reference assemblies -->
 	<PropertyGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+		<!-- Remove from /lib in NuGet -->
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<!-- Create reference Assemblies instead of a full assembly -->
 		<ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
+		<!-- Add our target for packing -->
+		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRefAssemblyToPackage</TargetsForTfmSpecificContentInPackage>
 	</PropertyGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+		<!-- Adding System.Reflection.Emit to satisfy the compiler -->
 		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" PrivateAssets="all" />
 		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" PrivateAssets="all" />
 	</ItemGroup>
+	<Target Name="AddRefAssemblyToPackage" Condition="$(TargetFramework) == 'netstandard2.0'">
+		<ItemGroup>
+			<!-- Adding the Reference Assembly and the xml documentation to /ref of NuGet -->
+			<TfmSpecificPackageFile Include="$(OutDir)$(AssemblyName).dll">
+				<PackagePath>ref/netstandard2.0</PackagePath>
+			</TfmSpecificPackageFile>
+			<TfmSpecificPackageFile Include="$(OutDir)$(AssemblyName).xml">
+				<PackagePath>ref/netstandard2.0</PackagePath>
+			</TfmSpecificPackageFile>
+		</ItemGroup>
+	</Target>
 
 	<ItemGroup Condition="$(IsNET5OrGreater)">
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -143,9 +143,8 @@
 		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRefAssemblyToPackage</TargetsForTfmSpecificContentInPackage>
 	</PropertyGroup>
 	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-		<!-- Adding System.Reflection.Emit to satisfy the compiler -->
-		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" PrivateAssets="all" />
-		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" PrivateAssets="all" />
+		<!-- Adding System.Reflection.Emit to because there are public types exposed from its's package -->
+		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
 	</ItemGroup>
 	<Target Name="AddRefAssemblyToPackage" Condition="$(TargetFramework) == 'netstandard2.0'">
 		<ItemGroup>


### PR DESCRIPTION
Just as we discussed, this adds support for using the netstandard2.0 target as a reference assembly.
The location of the reference assembly is in `/ref` instead of the standard `/lib` in the NuGet, so it won't ever be copied to the output path, avoiding any issues with the reference assembly being used as full fledged library in an unknown runtime implementation (.net core / .net framework)

The interesting thing is, we can ignore any IDE errors that are not related to the Public API (e.g. missing `DefinePInvokeMethod` and `CreateType` methods). Any implementation level compile errors do not matter.