### PR TITLE
Using `PlatformTriple.Current.GetIdentifiable` for a user submitted MethodInfo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<HarmonyVersion>2.3.0.0</HarmonyVersion>
 		<HarmonyPrerelease>-prerelease.3</HarmonyPrerelease>
-		<MonoModCoreVersion>1.0.0-prerelease.2</MonoModCoreVersion>
+		<MonoModCoreVersion>1.0.0</MonoModCoreVersion>
 	</PropertyGroup>
 
 </Project>

--- a/Harmony/Internal/HarmonySharedState.cs
+++ b/Harmony/Internal/HarmonySharedState.cs
@@ -1,5 +1,4 @@
 using Mono.Cecil;
-using MonoMod.Core.Platforms;
 using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
@@ -119,16 +118,13 @@ namespace HarmonyLib
 		internal static void UpdatePatchInfo(MethodBase original, MethodInfo replacement, PatchInfo patchInfo)
 		{
 			var bytes = patchInfo.Serialize();
-			// We assume that both `original` and `replacement` do not need `PlatformTriple.Current.GetIdentifiable`
 			lock (state) state[original] = bytes;
 			lock (originals) originals[replacement] = original;
 		}
 
 		internal static MethodBase GetOriginal(MethodInfo replacement)
 		{
-			// The runtime can return several different MethodInfo's that point to the same method. Use the correct one
-			var identifiableReplacement = PlatformTriple.Current.GetIdentifiable(replacement) as MethodInfo;
-			lock (originals) return originals.GetValueSafe(identifiableReplacement);
+			lock (originals) return originals.GetValueSafe(replacement);
 		}
 
 		internal static MethodBase FindReplacement(StackFrame frame)

--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -1,3 +1,4 @@
+using MonoMod.Core.Platforms;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -269,7 +270,9 @@ namespace HarmonyLib
 		public static MethodBase GetOriginalMethod(MethodInfo replacement)
 		{
 			if (replacement == null) throw new ArgumentNullException(nameof(replacement));
-			return HarmonySharedState.GetOriginal(replacement);
+			// The runtime can return several different MethodInfo's that point to the same method. Use the correct one
+			var identifiableReplacement = PlatformTriple.Current.GetIdentifiable(replacement) as MethodInfo;
+			return HarmonySharedState.GetOriginal(identifiableReplacement);
 		}
 
 		/// <summary>Tries to get the method from a stackframe including dynamic replacement methods</summary>


### PR DESCRIPTION
This fixed some cases when Harmony couldn't return the original method for a patch method
Also updated the  MonoMod