### PR TITLE
Way to override returned reference itself

### DIFF
--- a/Harmony/Documentation/articles/patching-injections.md
+++ b/Harmony/Documentation/articles/patching-injections.md
@@ -14,6 +14,10 @@ Patches can use an argument called **`__instance`** to access the instance value
 
 Patches can use an argument called **`__result`** to access the returned value. The type must match the return type of the original or be assignable from it. For prefixes, as the original method hasn't run yet, the value of `__result` is the default for that type. For most reference types, that would be `null`. If you wish to **alter** the `__result`, you need to define it **by reference** like `ref string name`.
 
+### __resultRef
+
+Patches can use an argument called **`__resultRef`** to alter the "**ref return**" reference itself. The type must be `RefResult<T>` by reference, where `T` must match the return type of the original, without `ref` modifier. For example `ref RefResult<string> __resultRef`.
+
 ### __state
 
 Patches can use an argument called **`__state`** to store information in the prefix method that can be accessed again in the postfix method. Think of it as a local variable. It can be any type and you are responsible to initialize its value in the prefix. **Note:** It only works if both patches are defined in the same class.

--- a/Harmony/Extras/RefResult.cs
+++ b/Harmony/Extras/RefResult.cs
@@ -1,0 +1,5 @@
+namespace HarmonyLib;
+
+/// <summary>Delegate type for "ref return" injections</summary>
+/// <typeparam name="T">Return type of the original method, without ref modifier</typeparam>
+public delegate ref T RefResult<T>();

--- a/HarmonyTests/Patching/Specials.cs
+++ b/HarmonyTests/Patching/Specials.cs
@@ -51,6 +51,49 @@ namespace HarmonyLibTests.Patching
 		}
 
 		[Test]
+		public void Test_PatchResultRef()
+		{
+			ResultRefStruct.numbersPrefix = [0, 0];
+			ResultRefStruct.numbersPostfix = [0, 0];
+			ResultRefStruct.numbersPostfixWithNull = [0];
+			ResultRefStruct.numbersFinalizer = [0];
+			ResultRefStruct.numbersMixed = [0, 0];
+
+			var test = new ResultRefStruct();
+
+			var instance = new Harmony("result-ref-test");
+			Assert.NotNull(instance);
+			var processor = instance.CreateClassProcessor(typeof(ResultRefStruct_Patch));
+			Assert.NotNull(processor, "processor");
+
+			test.ToPrefix() = 1;
+			test.ToPostfix() = 2;
+			test.ToPostfixWithNull() = 3;
+			test.ToMixed() = 5;
+
+			Assert.AreEqual(new[] { 1, 0 }, ResultRefStruct.numbersPrefix);
+			Assert.AreEqual(new[] { 2, 0 }, ResultRefStruct.numbersPostfix);
+			Assert.AreEqual(new[] { 3 }, ResultRefStruct.numbersPostfixWithNull);
+			Assert.Throws<Exception>(() => test.ToFinalizer(), "ToFinalizer method does not throw");
+			Assert.AreEqual(new[] { 5, 0 }, ResultRefStruct.numbersMixed);
+
+			var replacements = processor.Patch();
+			Assert.NotNull(replacements, "replacements");
+
+			test.ToPrefix() = -1;
+			test.ToPostfix() = -2;
+			test.ToPostfixWithNull() = -3;
+			test.ToFinalizer() = -4;
+			test.ToMixed() = -5;
+
+			Assert.AreEqual(new[] { 1, -1 }, ResultRefStruct.numbersPrefix);
+			Assert.AreEqual(new[] { 2, -2 }, ResultRefStruct.numbersPostfix);
+			Assert.AreEqual(new[] { -3 }, ResultRefStruct.numbersPostfixWithNull);
+			Assert.AreEqual(new[] { -4 }, ResultRefStruct.numbersFinalizer);
+			Assert.AreEqual(new[] { 42, -5 }, ResultRefStruct.numbersMixed);
+		}
+
+		[Test]
 		public void Test_Patch_ConcreteClass()
 		{
 			var instance = new Harmony("special-case-1");
@@ -327,7 +370,7 @@ namespace HarmonyLibTests.Patching
 			Assert.NotNull(patcher, "Patch processor");
 			_ = patcher.Patch();
 		}
-		
+
 		[Test]
 		public void Test_PatchEventHandler()
 		{
@@ -348,7 +391,7 @@ namespace HarmonyLibTests.Patching
 			new EventHandlerTestClass().Run();
 			Console.WriteLine($"### EventHandlerTestClass AFTER");
 		}
-		
+
 		[Test]
 		public void Test_PatchMarshalledClass()
 		{
@@ -369,7 +412,7 @@ namespace HarmonyLibTests.Patching
 			new MarshalledTestClass().Run();
 			Console.WriteLine($"### MarshalledTestClass AFTER");
 		}
-		
+
 		[Test]
 		public void Test_MarshalledWithEventHandler1()
 		{
@@ -390,7 +433,7 @@ namespace HarmonyLibTests.Patching
 			new MarshalledWithEventHandlerTest1Class().Run();
 			Console.WriteLine($"### MarshalledWithEventHandlerTest1 AFTER");
 		}
-		
+
 		[Test]
 		public void Test_MarshalledWithEventHandler2()
 		{


### PR DESCRIPTION
It is, on the whole, a suggestion. Currently, there is no way to override the reference itself in a method like `ref T fn()`
This implementation adds an optional parameter `out RefResult<T> __resultRef` (`out` is a requirement as it is called immediately after the patch and nulled), where `delegate ref T RefResult<T>()`
I don't have a user-case for this, but someone might have one

// On second thought, `out` requirement is unnecessary, `ref` is okay