### PR TITLE
Fix prefix skipping for dead-end code

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -164,7 +164,7 @@ namespace HarmonyLib
 
 			_ = AddPostfixes(privateVars, runOriginalVariable, false);
 
-			if (resultVariable is not null && hasReturnCode)
+			if (resultVariable is not null && (hasReturnCode || (methodEndsInDeadCode && skipOriginalLabel is not null)))
 				emitter.Emit(OpCodes.Ldloc, resultVariable);
 
 			var needsToStorePassthroughResult = AddPostfixes(privateVars, runOriginalVariable, true);
@@ -219,7 +219,7 @@ namespace HarmonyLib
 					emitter.Emit(OpCodes.Ldloc, resultVariable);
 			}
 
-			if (methodEndsInDeadCode == false || hasFinalizers || postfixes.Count > 0)
+			if (methodEndsInDeadCode == false || skipOriginalLabel is not null || hasFinalizers || postfixes.Count > 0)
 				emitter.Emit(OpCodes.Ret);
 
 			finalInstructions = emitter.GetInstructions();

--- a/HarmonyTests/Patching/Assets/Specials.cs
+++ b/HarmonyTests/Patching/Assets/Specials.cs
@@ -104,6 +104,8 @@ namespace HarmonyLibTests.Assets
 		public static void Prefix() => prefixCalled = true;
 
 		public static void Postfix() => postfixCalled = true;
+
+		public static bool PrefixWithControl() => false;
 	}
 
 	[HarmonyPatch(typeof(DeadEndCode), nameof(DeadEndCode.Method))]


### PR DESCRIPTION
Pretty simple fix, as title says