### PR TITLE
Added pdb generation

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -100,9 +100,9 @@
 	</PropertyGroup>
 	<ItemGroup Condition="$(TargetFramework)=='netstandard2.0'">
 		<!-- Adding System.Reflection.Emit.* because there are public types exposed from its's package -->
-		<PackageReference Include="System.Reflection.Emit" Version="4.7.0"  IncludeAssets="compile" />
-		<PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0"  IncludeAssets="compile" />
-		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0"  IncludeAssets="compile" />
+		<PackageReference Include="System.Reflection.Emit" Version="4.7.0" IncludeAssets="compile" />
+		<PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" PrivateAssets="all" IncludeAssets="compile" />
+		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" PrivateAssets="all" IncludeAssets="compile" />
 	</ItemGroup>
 	<Target Name="AddRefAssemblyToPackage" Condition="$(TargetFramework)=='netstandard2.0'">
 		<ItemGroup>

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -63,7 +63,6 @@
 		<Optimize>true</Optimize>
 		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<ClearOutputDirectory>True</ClearOutputDirectory>
 	</PropertyGroup>
 

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -63,6 +63,7 @@
 		<Optimize>true</Optimize>
 		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
+		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<ClearOutputDirectory>True</ClearOutputDirectory>
 	</PropertyGroup>
 

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -64,7 +64,7 @@
 		<DebugType>embedded</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
-		<ClearOutputDirectory>false</ClearOutputDirectory>
+		<ClearOutputDirectory>True</ClearOutputDirectory>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='ReleaseFat'">
@@ -72,7 +72,7 @@
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
-		<ClearOutputDirectory>false</ClearOutputDirectory>
+		<ClearOutputDirectory>True</ClearOutputDirectory>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(Configuration)'=='DebugThin' Or '$(Configuration)'=='ReleaseThin'">

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -33,10 +33,10 @@
 		<InformationalVersion>$(HarmonyVersion)$(HarmonyPrerelease)</InformationalVersion>
 		<NoWarn>$(NoWarn);SYSLIB0011;NU5131</NoWarn>
 		<Configurations>DebugThin;DebugFat;ReleaseThin;ReleaseFat</Configurations>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='net6.0' Or '$(TargetFramework)'=='net7.0' Or '$(TargetFramework)'=='net8.0'">
@@ -61,16 +61,16 @@
 
 	<PropertyGroup Condition="'$(Configuration)'=='ReleaseThin'">
 		<Optimize>true</Optimize>
-    <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+		<DebugType>embedded</DebugType>
+		<DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<ClearOutputDirectory>false</ClearOutputDirectory>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='ReleaseFat'">
 		<Optimize>true</Optimize>
-    <DebugType>portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<ClearOutputDirectory>false</ClearOutputDirectory>
 	</PropertyGroup>
@@ -146,12 +146,12 @@
 		<Delete Files="@(OldNugetPackages)" />
 	</Target>
 
-  <Target Name="RemoveFaultyPdb" BeforeTargets="Build">
-    <ItemGroup>
-      <FilesToDelete Include="$(ProjectDir)\$(OutDir)\MonoMod.ILHelpers.pdb"/>
-    </ItemGroup>
-    <Delete Files="@(FilesToDelete)" />
-  </Target>
+	<Target Name="RemoveFaultyPdb" BeforeTargets="Build">
+		<ItemGroup>
+			<FilesToDelete Include="$(ProjectDir)\$(OutDir)\MonoMod.ILHelpers.pdb"/>
+		</ItemGroup>
+		<Delete Files="@(FilesToDelete)" />
+	</Target>
 
 	<Target Name="CleanZip" AfterTargets="Clean">
 		<ItemGroup>

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -33,10 +33,10 @@
 		<InformationalVersion>$(HarmonyVersion)$(HarmonyPrerelease)</InformationalVersion>
 		<NoWarn>$(NoWarn);SYSLIB0011;NU5131</NoWarn>
 		<Configurations>DebugThin;DebugFat;ReleaseThin;ReleaseFat</Configurations>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='net6.0' Or '$(TargetFramework)'=='net7.0' Or '$(TargetFramework)'=='net8.0'">
@@ -59,12 +59,20 @@
 		<DefineConstants>DEBUG</DefineConstants>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)'=='ReleaseThin' Or '$(Configuration)'=='ReleaseFat'">
+	<PropertyGroup Condition="'$(Configuration)'=='ReleaseThin'">
 		<Optimize>true</Optimize>
-		<DebugType>portable</DebugType>
-		<DebugSymbols>false</DebugSymbols>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
-		<ClearOutputDirectory>True</ClearOutputDirectory>
+		<ClearOutputDirectory>false</ClearOutputDirectory>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'=='ReleaseFat'">
+		<Optimize>true</Optimize>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
+		<ClearOutputDirectory>false</ClearOutputDirectory>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(Configuration)'=='DebugThin' Or '$(Configuration)'=='ReleaseThin'">
@@ -137,6 +145,13 @@
 		</ItemGroup>
 		<Delete Files="@(OldNugetPackages)" />
 	</Target>
+
+  <Target Name="RemoveFaultyPdb" BeforeTargets="Build">
+    <ItemGroup>
+      <FilesToDelete Include="$(ProjectDir)\$(OutDir)\MonoMod.ILHelpers.pdb"/>
+    </ItemGroup>
+    <Delete Files="@(FilesToDelete)" />
+  </Target>
 
 	<Target Name="CleanZip" AfterTargets="Clean">
 		<ItemGroup>

--- a/ILRepack.targets
+++ b/ILRepack.targets
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'DebugFat' Or '$(Configuration)' == 'ReleaseFat'">
+		<PropertyGroup>
+			<DebugInfo Condition="'$(TargetFramework)' == 'netstandard2.0'">false</DebugInfo>
+			<DebugInfo Condition="'$(TargetFramework)' != 'netstandard2.0'">true</DebugInfo>
+		</PropertyGroup>
 		<ItemGroup>
 			<InputAssemblies Include="$(OutputPath)\*.dll" />
 		</ItemGroup>
 		<ILRepack
 			InputAssemblies="@(InputAssemblies)"
 			OutputFile="$(OutputPath)\$(AssemblyName).dll"
+			DebugInfo="$(DebugInfo)"
 			CopyAttributes="false"
 			XmlDocumentation="true"
 			Internalize="true"


### PR DESCRIPTION
* for Thin they are embedded
* for Fat they are portable
Removed snupkg generation, the .pdb files are included in the nupkg

Side fix:
Exclude the secondary System.Reflection.* packages from NuGet - we were adding new dependencies that we don't really need