### PR TITLE
Added pdb generation  2

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -162,10 +162,10 @@
 	</Target>
 
 	<Target Name="RemoveExtraDlls" AfterTargets="Pack">
-		<ItemGroup Condition="'$(Configuration)'=='DebugThin' Or '$(Configuration)'=='ReleaseThin'">
-			<ExtraDlls Include="$(MSBuildThisFileDirectory)bin\**\MonoMod.*.dll" />
-			<ExtraDlls Include="$(MSBuildThisFileDirectory)bin\**\Mono.*.dll" />
-			<ExtraDlls Include="$(MSBuildThisFileDirectory)bin\**\System.*.dll" />
+		<ItemGroup>
+			<ExtraDlls Include="$(MSBuildThisFileDirectory)bin\**\MonoMod.*.*" />
+			<ExtraDlls Include="$(MSBuildThisFileDirectory)bin\**\Mono.*.*" />
+			<ExtraDlls Include="$(MSBuildThisFileDirectory)bin\**\System.*.*" />
 		</ItemGroup>
 		<Delete Files="@(ExtraDlls)" />
 	</Target>

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -35,7 +35,6 @@
 		<Configurations>DebugThin;DebugFat;ReleaseThin;ReleaseFat</Configurations>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 	</PropertyGroup>
 
@@ -61,7 +60,7 @@
 
 	<PropertyGroup Condition="'$(Configuration)'=='ReleaseThin'">
 		<Optimize>true</Optimize>
-		<DebugType>embedded</DebugType>
+		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<ClearOutputDirectory>True</ClearOutputDirectory>
@@ -73,6 +72,7 @@
 		<DebugSymbols>true</DebugSymbols>
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<ClearOutputDirectory>True</ClearOutputDirectory>
+		<CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(Configuration)'=='DebugThin' Or '$(Configuration)'=='ReleaseThin'">


### PR DESCRIPTION
Corrections based on the feedback:
* Exclude pdb copy from NuGet packages for thin
* Thin now includes the debug symbols as portable
* Always exclude the .dll/pdb/xml files of the dependencies after Pack