### PR TITLE
Ensure build works when .NET Core 3.1 or 5.0 is not installed

### DIFF
--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -87,6 +87,15 @@
 		<!-- Reference assemblies are needed for non-Windows .NET Framework targeting builds. -->
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<!-- Ensure the ref assemblies for .NET Core are on disk.
+			Needed by ILRepack to resolve framework references for each platform.
+			Ensures the build (ILRepack task) can work without having all these versions installed. -->
+		<PackageReference Condition="$(TargetFramework) == 'netcoreapp3.0'" Include="Microsoft.NetCore.App.Ref" Version="3.0.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageReference Condition="$(TargetFramework) == 'netcoreapp3.1'" Include="Microsoft.NetCore.App.Ref" Version="3.1.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageReference Condition="$(TargetFramework) == 'net5.0'" Include="Microsoft.NetCore.App.Ref" Version="5.0.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageReference Condition="$(TargetFramework) == 'net6.0'" Include="Microsoft.NetCore.App.Ref" Version="6.0.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageReference Condition="$(TargetFramework) == 'net7.0'" Include="Microsoft.NetCore.App.Ref" Version="7.0.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+		<PackageReference Condition="$(TargetFramework) == 'net8.0'" Include="Microsoft.NetCore.App.Ref" Version="8.0.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
 	</ItemGroup>
 
 	<!-- netstandard2.0 reference assemblies -->

--- a/ILRepack.targets
+++ b/ILRepack.targets
@@ -8,8 +8,17 @@
 		<ItemGroup>
 			<InputAssemblies Include="$(OutputPath)\*.dll" />
 		</ItemGroup>
+		<ItemGroup>
+			<LibraryPath Condition="$(TargetFramework) == 'netcoreapp3.0'" Include="$(PkgMicrosoft_NetCore_App_Ref)\ref\netcoreapp3.0" />
+			<LibraryPath Condition="$(TargetFramework) == 'netcoreapp3.1'" Include="$(PkgMicrosoft_NetCore_App_Ref)\ref\netcoreapp3.1" />
+			<LibraryPath Condition="$(TargetFramework) == 'net5.0'" Include="$(PkgMicrosoft_NetCore_App_Ref)\ref\net5.0" />
+			<LibraryPath Condition="$(TargetFramework) == 'net6.0'" Include="$(PkgMicrosoft_NetCore_App_Ref)\ref\net6.0" />
+			<LibraryPath Condition="$(TargetFramework) == 'net7.0'" Include="$(PkgMicrosoft_NetCore_App_Ref)\ref\net7.0" />
+			<LibraryPath Condition="$(TargetFramework) == 'net8.0'" Include="$(PkgMicrosoft_NetCore_App_Ref)\ref\net8.0" />
+		</ItemGroup>
 		<ILRepack
 			InputAssemblies="@(InputAssemblies)"
+			LibraryPath="@(LibraryPath)"
 			OutputFile="$(OutputPath)\$(AssemblyName).dll"
 			DebugInfo="$(DebugInfo)"
 			CopyAttributes="false"


### PR DESCRIPTION
ILRepack usually resolves framework assemblies from the dotnet SDK directories if the corresponding .NET Core version is installed. If it's not installed, let's download Microsoft.NetCore.App.Ref NuGet package (equivalent of Microsoft.NETFramework.ReferenceAssemblies but for Core) of the specified version and pass the path to ILRepack so it can find the .dlls there.

Confirmed this fixes the build.