### PR TITLE
Use the local ReleaseRef package for easier releasing

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -62,4 +62,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Harmony-${{inputs.build_configuration}}-${{inputs.os}}
-          path: Harmony/bin/Harmony*.zip
+          path: Harmony/bin/*.zip

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -180,6 +180,9 @@
 		<ZipDirectory SourceDirectory="$(MSBuildThisFileDirectory)bin\$(Configuration)" DestinationFile="$(MSBuildThisFileDirectory)bin\Harmony-Ref.$(Version).zip" Overwrite="true" Condition="'$(Configuration)'=='ReleaseRef'" />
 		<ZipDirectory SourceDirectory="$(MSBuildThisFileDirectory)bin\$(Configuration)" DestinationFile="$(MSBuildThisFileDirectory)bin\Harmony-Thin.$(Version).zip" Overwrite="true" Condition="'$(Configuration)'=='ReleaseThin'" />
 		<ZipDirectory SourceDirectory="$(MSBuildThisFileDirectory)bin\$(Configuration)" DestinationFile="$(MSBuildThisFileDirectory)bin\Harmony-Fat.$(Version).zip" Overwrite="true" Condition="'$(Configuration)'=='ReleaseFat'" />
+		<ZipDirectory SourceDirectory="$(MSBuildThisFileDirectory)..\packages" DestinationFile="$(MSBuildThisFileDirectory)bin\NuGet-Ref.$(Version).zip" Overwrite="true" Condition="'$(Configuration)'=='ReleaseRef'" />
+		<ZipDirectory SourceDirectory="$(MSBuildThisFileDirectory)..\packages" DestinationFile="$(MSBuildThisFileDirectory)bin\NuGet-Thin.$(Version).zip" Overwrite="true" Condition="'$(Configuration)'=='ReleaseThin'" />
+		<ZipDirectory SourceDirectory="$(MSBuildThisFileDirectory)..\packages" DestinationFile="$(MSBuildThisFileDirectory)bin\NuGet-Fat.$(Version).zip" Overwrite="true" Condition="'$(Configuration)'=='ReleaseFat'" />
 	</Target>
 
 	<!-- ReleaseRef -->

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -38,6 +38,10 @@
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<ClearOutputDirectory>True</ClearOutputDirectory>
+		<RestoreAdditionalProjectSources>
+			https://api.nuget.org/v3/index.json;
+			$(MSBuildThisFileDirectory)/bin/ReleaseRef/;
+		</RestoreAdditionalProjectSources>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net5.0' Or '$(TargetFramework)'=='net6.0' Or '$(TargetFramework)'=='net7.0' Or '$(TargetFramework)'=='net8.0'">

--- a/Harmony/Harmony.csproj
+++ b/Harmony/Harmony.csproj
@@ -38,9 +38,10 @@
 		<ILRepackTargetsFile>$(SolutionDir)ILRepack.targets</ILRepackTargetsFile>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 		<ClearOutputDirectory>True</ClearOutputDirectory>
+		<PackageOutputPath>../packages</PackageOutputPath>
 		<RestoreAdditionalProjectSources>
 			https://api.nuget.org/v3/index.json;
-			$(MSBuildThisFileDirectory)/bin/ReleaseRef/;
+			$(MSBuildThisFileDirectory)../packages;
 		</RestoreAdditionalProjectSources>
 	</PropertyGroup>
 

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Taken from BepInEx, it's atrocious how badly `RestoreAdditionalProjectSources` is documented