### PR TITLE
Allows empty string for targeting special MethodType options and doesn't try searching for it with AccessTools

### DIFF
--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -90,17 +90,17 @@ namespace HarmonyLib
 				switch (attr.methodType)
 				{
 					case MethodType.Normal:
-						if (attr.methodName is null)
+						if (string.IsNullOrEmpty(attr.methodName))
 							return null;
 						return AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
 
 					case MethodType.Getter:
-						if (attr.methodName is null)
+						if (string.IsNullOrEmpty(attr.methodName))
 							return AccessTools.DeclaredIndexerGetter(attr.declaringType, attr.argumentTypes);
 						return AccessTools.DeclaredPropertyGetter(attr.declaringType, attr.methodName);
 
 					case MethodType.Setter:
-						if (attr.methodName is null)
+						if (string.IsNullOrEmpty(attr.methodName))
 							return AccessTools.DeclaredIndexerSetter(attr.declaringType, attr.argumentTypes);
 						return AccessTools.DeclaredPropertySetter(attr.declaringType, attr.methodName);
 
@@ -113,14 +113,14 @@ namespace HarmonyLib
 							.FirstOrDefault();
 
 					case MethodType.Enumerator:
-						if (attr.methodName is null)
+						if (string.IsNullOrEmpty(attr.methodName))
 							return null;
 						var enumMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
 						return AccessTools.EnumeratorMoveNext(enumMethod);
 
 #if NET45_OR_GREATER || NETSTANDARD || NETCOREAPP
 					case MethodType.Async:
-						if (attr.methodName is null)
+						if (string.IsNullOrEmpty(attr.methodName))
 							return null;
 						var asyncMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
 						return AccessTools.AsyncMoveNext(asyncMethod);

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -149,9 +149,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.DeclaredField: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.DeclaredField: name is null");
+				FileLog.Debug("AccessTools.DeclaredField: name is null/empty");
 				return null;
 			}
 			var fieldInfo = type.GetField(name, allDeclared);
@@ -183,9 +183,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.Field: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.Field: name is null");
+				FileLog.Debug("AccessTools.Field: name is null/empty");
 				return null;
 			}
 			var fieldInfo = FindIncludingBaseTypes(type, t => t.GetField(name, all));
@@ -234,9 +234,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.DeclaredProperty: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.DeclaredProperty: name is null");
+				FileLog.Debug("AccessTools.DeclaredProperty: name is null/empty");
 				return null;
 			}
 			var property = type.GetProperty(name, allDeclared);
@@ -338,9 +338,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.Property: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.Property: name is null");
+				FileLog.Debug("AccessTools.Property: name is null/empty");
 				return null;
 			}
 			var property = FindIncludingBaseTypes(type, t => t.GetProperty(name, all));
@@ -446,9 +446,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.DeclaredMethod: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.DeclaredMethod: name is null");
+				FileLog.Debug("AccessTools.DeclaredMethod: name is null/empty");
 				return null;
 			}
 			MethodInfo result;
@@ -495,9 +495,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.Method: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.Method: name is null");
+				FileLog.Debug("AccessTools.Method: name is null/empty");
 				return null;
 			}
 			MethodInfo result;
@@ -857,9 +857,9 @@ namespace HarmonyLib
 				FileLog.Debug("AccessTools.Inner: type is null");
 				return null;
 			}
-			if (name is null)
+			if (string.IsNullOrEmpty(name))
 			{
-				FileLog.Debug("AccessTools.Inner: name is null");
+				FileLog.Debug("AccessTools.Inner: name is null/empty");
 				return null;
 			}
 			return FindIncludingBaseTypes(type, t => t.GetNestedType(name, all));
@@ -1722,7 +1722,6 @@ namespace HarmonyLib
 		{
 			var method = DeclaredMethod(typeColonName);
 			return MethodDelegate<DelegateType>(method, instance, virtualCall);
-
 		}
 
 		/// <summary>Creates a delegate for a given delegate definition, attributed with [<see cref="HarmonyLib.HarmonyDelegate"/>]</summary>


### PR DESCRIPTION
Allows patch attributes like `[HarmonyPatch(typeof(TargetType), "", MethodType.Getter)]` on a method, or
```cs
[HarmonyPatch(typeof(TargetType))]
static class PatchClass
{
    [HarmonyPatch("", MethodType.Getter)]
    static void Postfix() { }
}
```
to target an Indexer for example. With just `null` instead of `""`, the second example would be ambiguous.

This may allow making the targeting "nameless" members like (static) constructors or indexers more explicit, by allowing to provide an empty string in addition to the MethodType or `null`. Now that I'm writing this, it seems almost unnecessary, but the idea came while [talking about possible Analyzers for HarmonyPatch attributes](https://discord.com/channels/131466550938042369/674571535570305060/1278776582797918310)

For the AccessTools methods, it checks for empty string as well, as there can't be members with that name. Not with whitespace either, but net3.5 doesn't have that method.