### PR TITLE
update MonoMod.Core to 1.2.2 to address net9 issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<HarmonyVersion>2.3.3.0</HarmonyVersion>
 		<HarmonyPrerelease></HarmonyPrerelease>
-		<MonoModCoreVersion>1.2.1</MonoModCoreVersion>
+		<MonoModCoreVersion>1.2.2</MonoModCoreVersion>
 	</PropertyGroup>
 
 </Project>

--- a/HarmonyTests/IL/TestMethodBodyReader.cs
+++ b/HarmonyTests/IL/TestMethodBodyReader.cs
@@ -66,7 +66,11 @@ namespace HarmonyLibTests.IL
 #else
 					Assert.AreEqual("System.Reflection.LocalVariableInfo", instrNoGen.argument.GetType().FullName, "w/o generator argument type @ {0} ({1})", i, instrNoGen);
 #endif
+#if NET9_0_OR_GREATER
+					Assert.AreEqual(Type.GetType("System.Reflection.Emit.RuntimeLocalBuilder"), instrHasGen.argument.GetType(), "w/ generator argument type @ {0} ({1})", i, instrNoGen);
+#else
 					Assert.AreEqual(typeof(LocalBuilder), instrHasGen.argument.GetType(), "w/ generator argument type @ {0} ({1})", i, instrNoGen);
+#endif
 				}
 			}
 		}


### PR DESCRIPTION
This PR address the issue with Harmony when running under .NET 9. As @tyb-dev pointed out, .NET 9 changed LocalBuilder from `sealed partial class` to `abstract class`. Due to this, `MonoMod.Core` on `1.2.1` was failing because it was attempting to create an instance of LocalBuilder, resulting in the following:

```
System.MemberAccessException : Cannot create an instance of System.Reflection.Emit.LocalBuilder because it is an abstract class.
```

`MonoMod.Core` was updated to `1.2.2` roughly six days ago to address this update to `LocalBuilder`. Updating the package reference to `1.2.2` addresses this issue with Harmony, and all tests are now passing. There was one test that required an update due to type checking for `LocalBuilder` (now `RuntimeLocalBuilder` when on .NET 9).