### PR TITLE
fix patching-transpiler-matcher note image

### DIFF
--- a/Harmony/Documentation/articles/patching-transpiler-matcher.md
+++ b/Harmony/Documentation/articles/patching-transpiler-matcher.md
@@ -27,3 +27,5 @@ The `Kill()` method might be called more than once. For this it is possible to u
 [!code-csharp[example](../examples/patching-transpiler-codematcher.cs?name=repeat)]
 
 ![note] `Repeat` will not use a `CodeMatcher.Search...()`, only `Match...()` methods can be repeated. If you consider using another method `Match...()` in the "matchAction", clone your `CodeMatcher` into the match action via `CodeMatcher.Clone()`. This is to not replace the old match used by `Repeat`.
+
+[note]: https://raw.githubusercontent.com/pardeike/Harmony/master/Harmony/Documentation/images/note.png


### PR DESCRIPTION
`![note]` inside patching-transpiler-matcher does not display correctly.

when I wrote the article I forgot to add
```md
[note]: https://raw.githubusercontent.com/pardeike/Harmony/master/Harmony/Documentation/images/note.png
```

I thought I had to deal with the `![note]` of [docfx](https://dotnet.github.io/docfx/docs/markdown.html?tabs=linux%2Cdotnet#alerts).

I added the link to the image and it's now fix.