### PR TITLE
remove debugger log

### DIFF
--- a/Harmony/Internal/MethodCopier.cs
+++ b/Harmony/Internal/MethodCopier.cs
@@ -587,10 +587,6 @@ namespace HarmonyLib
 					var signature = InlineSignatureParser.ImportCallSite(module, bytes);
 					instruction.operand = signature;
 					instruction.argument = signature;
-					Debugger.Log(0, "TEST", $"METHOD {method.FullDescription()}\n");
-					Debugger.Log(0, "TEST", $"Signature Blob = {bytes.Select(b => string.Format("0x{0:x02}", b)).Aggregate((a, b) => a + " " + b)}\n");
-					Debugger.Log(0, "TEST", $"Signature = {signature}\n");
-					Debugger.Break();
 					break;
 				}
 


### PR DESCRIPTION
I was trying to patch methods in the `GL` class from opentk and it jumped to this line in code when running in debug mode. It looks like there is a leftover `Debugger` break and logging. Harmony is able to patch the method without issue other than this.