### PR TITLE
Fix using __args argument on a patch targetting a method with an out bool parameter to fail on the Unity Mono platform

### DIFF
--- a/Harmony/Internal/MethodPatcher.cs
+++ b/Harmony/Internal/MethodPatcher.cs
@@ -378,6 +378,8 @@ namespace HarmonyLib
 			if (type == typeof(int)) return OpCodes.Ldind_I4;
 			if (type == typeof(long)) return OpCodes.Ldind_I8;
 
+			if (type == typeof(bool)) return OpCodes.Ldind_I4;
+
 			return OpCodes.Ldind_Ref;
 		}
 
@@ -398,6 +400,9 @@ namespace HarmonyLib
 			if (type == typeof(short)) return OpCodes.Stind_I2;
 			if (type == typeof(int)) return OpCodes.Stind_I4;
 			if (type == typeof(long)) return OpCodes.Stind_I8;
+
+
+			if (type == typeof(bool)) return OpCodes.Stind_I4;
 
 			return OpCodes.Stind_Ref;
 		}


### PR DESCRIPTION
Discussion started here: https://discord.com/channels/131466550938042369/361891646742462467/1357738423535796244

A small reproduceable sample code is seen here (as a UnityModManager mod)
![grafik](https://github.com/user-attachments/assets/ac677b2c-bf82-47b9-852e-ddd1c708b6ab)

I added a fix and a test.

Note: I could ***only*** reproduce on the Unity Mono runtime. Testing on .NET or .NET Framework (at least the versions I tried) didn't produce the error under the same conditions.

See test case in #658 

