### PR TITLE
Add more tests concerning usage of __args array with various types of out parameters

### DIFF
--- a/HarmonyTests/Patching/Arguments.cs
+++ b/HarmonyTests/Patching/Arguments.cs
@@ -328,13 +328,31 @@ namespace HarmonyLibTests.Patching
 			var f2 = new float[] { 9f };
 			var b1 = true;
 			var b2 = true;
+			var e1 = ArgumentArrayMethods.ShorterThanNormal.y;
+			var e2 = ArgumentArrayMethods.ShorterThanNormal.y;
+			var e4 = ArgumentArrayMethods.LongerThanNormal.z;
+			var e5 = ArgumentArrayMethods.LongerThanNormal.z;
+			var p1 = new UIntPtr(9);
+			var p2 = new UIntPtr(10);
+			var m1 = (nuint)11;
+			var m2 = (nuint)22;
+			var d1 = new DateTime(11);
+			var d2 = new DateTime(12);
+			var k1 = 1111M;
+			var k2 = 2222M;
 
 			instance.Method(
 				n1, ref n2, out var n3,
 				s1, ref s2, out var s3,
 				st1, ref st2, out var st3,
 				f1, ref f2, out var f3,
-				b1, ref b2, out var b3
+				b1, ref b2, out var b3,
+				e1, ref e2, out var e3,
+				e4, ref e5, out var e6,
+				p1, ref p2, out var p3,
+				m1, ref m2, out var m3,
+				d1, ref d2, out var d3,
+				k1, ref k2, out var k3
 			);
 
 			// prefix input
@@ -356,9 +374,33 @@ namespace HarmonyLibTests.Patching
 			Assert.AreEqual(9f, ((float[])r[i])[0], $"prefix[{i++}]");
 			Assert.AreEqual(null, (float[])r[i], $"prefix[{i++}]");
 
-			Assert.AreEqual(true, (bool)r[i], $"prefix[{i++}]");
-			Assert.AreEqual(true, (bool)r[i], $"prefix[{i++}]");
-			Assert.AreEqual(false, (bool)r[i], $"prefix[{i++}]");
+			Assert.AreEqual(true, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(true, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(false, r[i], $"prefix[{i++}]");
+
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.y, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.y, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.a, r[i], $"prefix[{i++}]");
+
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.z, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.z, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.c, r[i], $"prefix[{i++}]");
+
+			Assert.AreEqual(new UIntPtr(9), r[i], $"prefix[{i++}]");
+			Assert.AreEqual(new UIntPtr(10), r[i], $"prefix[{i++}]");
+			Assert.AreEqual(new UIntPtr(0), r[i], $"prefix[{i++}]");
+
+			Assert.AreEqual((nuint)11, r[i], $"prefix[{i++}]");
+			Assert.AreEqual((nuint)22, r[i], $"prefix[{i++}]");
+			Assert.AreEqual((nuint)0, r[i], $"prefix[{i++}]");
+
+			Assert.AreEqual(new DateTime(11),r[i], $"prefix[{i++}]");
+			Assert.AreEqual(new DateTime(12), r[i], $"prefix[{i++}]");
+			Assert.AreEqual(new DateTime(0), r[i], $"prefix[{i++}]");
+
+			Assert.AreEqual(1111M, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(2222M, r[i], $"prefix[{i++}]");
+			Assert.AreEqual(0M, r[i], $"prefix[{i++}]");
 
 			// postfix input
 			r = ArgumentArrayPatches.postfixInput;
@@ -379,9 +421,33 @@ namespace HarmonyLibTests.Patching
 			Assert.AreEqual(5.6f, ((float[])r[i])[2], $"postfix[{i++}]");
 			Assert.AreEqual(6.5f, ((float[])r[i])[2], $"postfix[{i++}]");
 
-			Assert.AreEqual(true, (bool)r[i], $"postfix[{i++}]");
-			Assert.AreEqual(false, (bool)r[i], $"postfix[{i++}]");
-			Assert.AreEqual(true, (bool)r[i], $"postfix[{i++}]");
+			Assert.AreEqual(true, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(false, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(true, r[i], $"postfix[{i++}]");
+
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.y, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.a, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.b, r[i], $"postfix[{i++}]");
+
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.z, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.c, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.d, r[i], $"postfix[{i++}]");
+
+			Assert.AreEqual(new UIntPtr(9), r[i], $"postfix[{i++}]");
+			Assert.AreEqual(new UIntPtr(1), r[i], $"postfix[{i++}]");
+			Assert.AreEqual(new UIntPtr(2), r[i], $"postfix[{i++}]");
+
+			Assert.AreEqual((nuint)11, r[i], $"postfix[{i++}]");
+			Assert.AreEqual((nuint)789, r[i], $"postfix[{i++}]");
+			Assert.AreEqual((nuint)101, r[i], $"postfix[{i++}]");
+
+			Assert.AreEqual(new DateTime(11), r[i], $"postfix[{i++}]");
+			Assert.AreEqual(new DateTime(3), r[i], $"postfix[{i++}]");
+			Assert.AreEqual(new DateTime(4), r[i], $"postfix[{i++}]");
+
+			Assert.AreEqual(1111M, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(666M, r[i], $"postfix[{i++}]");
+			Assert.AreEqual(777M, r[i], $"postfix[{i++}]");
 
 			// method output values
 			Assert.AreEqual(123, n2, "n2");
@@ -392,9 +458,20 @@ namespace HarmonyLibTests.Patching
 			Assert.AreEqual(456, st3.n, "st3");
 			Assert.AreEqual(5.6f, f2[2], "f2");
 			Assert.AreEqual(6.5f, f3[2], "f3");
-			Assert.AreEqual(true, b1, $"b1");
 			Assert.AreEqual(false, b2, $"b2");
 			Assert.AreEqual(true, b3, $"b3");
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.a, e2, $"e2");
+			Assert.AreEqual(ArgumentArrayMethods.ShorterThanNormal.b, e3, $"e3");
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.c, e5, $"e5");
+			Assert.AreEqual(ArgumentArrayMethods.LongerThanNormal.d, e6, $"e6");
+			Assert.AreEqual(new UIntPtr(1), p2, $"p2");
+			Assert.AreEqual(new UIntPtr(2), p3, $"p3");
+			Assert.AreEqual((nuint)789, m2, $"m2");
+			Assert.AreEqual((nuint)101, m3, $"m3");
+			Assert.AreEqual(new DateTime(3), d2, $"d2");
+			Assert.AreEqual(new DateTime(4), d3, $"d3");
+			Assert.AreEqual(666M, k2, $"k2");
+			Assert.AreEqual(777M, k3, $"k3");
 		}
 
 		[Test]

--- a/HarmonyTests/Patching/Assets/ArgumentCases.cs
+++ b/HarmonyTests/Patching/Assets/ArgumentCases.cs
@@ -173,14 +173,31 @@ namespace HarmonyLibTests.Assets
 		{
 			public int n;
 		}
-
+		public enum ShorterThanNormal : sbyte
+		{
+			a,
+			b,
+			y
+		}
+		public enum LongerThanNormal : ulong
+		{
+			c,
+			d,
+			z
+		}
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public void Method(
 			int n1, ref int n2, out int n3,
 			string s1, ref string s2, out string s3,
 			SomeStruct st1, ref SomeStruct st2, out SomeStruct st3,
 			float[] f1, ref float[] f2, out float[] f3,
-			bool b1, ref bool b2, out bool b3
+			bool b1, ref bool b2, out bool b3,
+			ShorterThanNormal e1, ref ShorterThanNormal e2, out ShorterThanNormal e3,
+			LongerThanNormal e4, ref LongerThanNormal e5, out LongerThanNormal e6,
+			UIntPtr p1, ref UIntPtr p2, out UIntPtr p3,
+			nuint m1, ref nuint m2, out nuint m3,
+			DateTime d1, ref DateTime d2, out DateTime d3,
+			decimal k1, ref decimal k2, out decimal k3
 		)
 		{
 			n2 = 12;
@@ -193,6 +210,18 @@ namespace HarmonyLibTests.Assets
 			f3 = [2f, 4f, 6f];
 			b2 = true;
 			b3 = false;
+			e2 = ShorterThanNormal.b;
+			e3 = ShorterThanNormal.a;
+			e5 = LongerThanNormal.d;
+			e6 = LongerThanNormal.c;
+			p2 = new(5);
+			p3 = new(6);
+			m2 = 11;
+			m3 = 22;
+			d2 = new(7);
+			d3 = new(8);
+			k2 = 444M;
+			k3 = 555M;
 		}
 	}
 
@@ -201,7 +230,6 @@ namespace HarmonyLibTests.Assets
 	{
 		public static object[] prefixInput;
 		public static object[] postfixInput;
-
 		public static bool Prefix(object[] __args)
 		{
 			prefixInput = (object[])Array.CreateInstance(typeof(object), __args.Length);
@@ -222,6 +250,24 @@ namespace HarmonyLibTests.Assets
 			__args[13] = false;
 			__args[14] = true;
 
+			__args[16] = ArgumentArrayMethods.ShorterThanNormal.a;
+			__args[17] = ArgumentArrayMethods.ShorterThanNormal.b;
+
+			__args[19] = ArgumentArrayMethods.LongerThanNormal.c;
+			__args[20] = ArgumentArrayMethods.LongerThanNormal.d;
+
+			__args[22] = new UIntPtr(1);
+			__args[23] = new UIntPtr(2);
+
+			__args[25] = (nuint)789;
+			__args[26] = (nuint)101;
+
+			__args[28] = new DateTime(3);
+			__args[29] = new DateTime(4);
+
+			__args[31] = 666M;
+			__args[32] = 777M;
+
 			return false;
 		}
 
@@ -230,7 +276,13 @@ namespace HarmonyLibTests.Assets
 			string s1, string s2, string s3,
 			ArgumentArrayMethods.SomeStruct st1, ArgumentArrayMethods.SomeStruct st2, ArgumentArrayMethods.SomeStruct st3,
 			float[] f1, float[] f2, float[] f3,
-			bool b1, bool b2, bool b3
+			bool b1, bool b2, bool b3,
+			ArgumentArrayMethods.ShorterThanNormal e1, ArgumentArrayMethods.ShorterThanNormal e2, ArgumentArrayMethods.ShorterThanNormal e3,
+			ArgumentArrayMethods.LongerThanNormal e4, ArgumentArrayMethods.LongerThanNormal e5, ArgumentArrayMethods.LongerThanNormal e6,
+			UIntPtr p1, UIntPtr p2, UIntPtr p3,
+			nuint m1, nuint m2, nuint m3,
+			DateTime d1, DateTime d2, DateTime d3,
+			decimal k1, decimal k2, decimal k3
 		)
 		{
 			postfixInput =
@@ -239,7 +291,13 @@ namespace HarmonyLibTests.Assets
 				s1, s2, s3,
 				st1, st2, st3,
 				f1, f2, f3,
-				b1, b2, b3
+				b1, b2, b3,
+				e1, e2, e3,
+				e4, e5, e6,
+				p1, p2, p3,
+				m1, m2, m3,
+				d1, d2, d3,
+				k1, k2, k3
 			];
 		}
 	}


### PR DESCRIPTION
Related: #657

Currently, the following types are definitely causing issues (Unity Mono): `char`, `nint`, `nuint`, `decimal` and enums longer than I4