### PR TITLE
Fix different patches using  ref SomeType __state  and SomeType __state causing InvalidProgram in .NET6+

### DIFF
--- a/Harmony/Internal/MethodCreator.cs
+++ b/Harmony/Internal/MethodCreator.cs
@@ -76,7 +76,11 @@ namespace HarmonyLib
 				if (config.HasLocal(varName)) return;
 				foreach (var injection in config.InjectionsFor(fix, InjectionType.State))
 				{
-					var privateStateVariable = config.DeclareLocal(injection.parameterInfo.ParameterType);
+					var parameterType = injection.parameterInfo.ParameterType;
+					var type = parameterType.IsByRef
+					 ? parameterType.GetElementType()
+					 : parameterType;
+					var privateStateVariable = config.DeclareLocal(type);
 					config.AddLocal(varName, privateStateVariable);
 					config.AddCodes(this.GenerateVariableInit(privateStateVariable));
 				}


### PR DESCRIPTION
Fix different patches using 
```cs
ref SomeType __state
```
and 
```cs
SomeType __state
```
on the same method causing InvalidProgramException in .NET 6