### PR TITLE
Fix Reverse Patch Test failing. 

### DIFF
--- a/HarmonyTests/ReversePatching/Assets/ReversePatches.cs
+++ b/HarmonyTests/ReversePatching/Assets/ReversePatches.cs
@@ -35,7 +35,11 @@ namespace HarmonyLibTests.Assets
 					item => item.opcode == OpCodes.Ldarg_1,
 					item => item.opcode = OpCodes.Ldarg_0
 				).ToList();
+#if NET9_0_OR_GREATER
+				var mJoin = AccessTools.Method(typeof(string), nameof(string.Join), [typeof(string), typeof(ReadOnlySpan<string>)]);
+#else
 				var mJoin = AccessTools.Method(typeof(string), nameof(string.Join), [typeof(string), typeof(string[])]);
+#endif
 				var idx = list.FindIndex(item => item.opcode == OpCodes.Call && item.operand as MethodInfo == mJoin);
 				list.RemoveRange(idx + 1, list.Count - (idx + 1));
 				list.Add(new CodeInstruction(OpCodes.Ret));


### PR DESCRIPTION
For some reason the targetted method now uses an implicit string[] => ReadOnlySpan<string> conversion on .NET 9 (which it didn't do before the refactor). The Transpiler fails to find a valid match because of that which results in invalid IL