### PR TITLE
Simplify CI labels

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   build-output-cache:
-    name: Upload Test Build Output Cache
+    name: ${{ inputs.build_configuration }}
     runs-on: ${{inputs.image}}
     if: ${{!inputs.manual_build || inputs.publish}}
     timeout-minutes: 10

--- a/.github/workflows/test-qemu-dotnet.yml
+++ b/.github/workflows/test-qemu-dotnet.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   unix-net:
-    name: .NET ubuntu-arm64 ${{ inputs.target_framework }} ${{ inputs.build_configuration }}
+    name: ${{ inputs.build_configuration }}
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test-qemu-mono.yml
+++ b/.github/workflows/test-qemu-mono.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   ubuntu-mono-arm64:
-    name: Mono ubuntu-arm64 ${{ inputs.target_framework }} ${{ inputs.build_configuration }}
+    name: ${{ inputs.build_configuration }}
     runs-on: ubuntu-latest
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test-result-upload.yml
+++ b/.github/workflows/test-result-upload.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-binaries:
-    name: Build Binaries
+    name: Results
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/test-unix-dotnet.yml
+++ b/.github/workflows/test-unix-dotnet.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   unix-net:
-    name: .NET ${{inputs.os}}-${{inputs.architecture}} ${{ inputs.target_framework }} ${{inputs.build_configuration}}
+    name: ${{inputs.build_configuration}}
     runs-on: ${{inputs.image}}
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test-unix-mono.yml
+++ b/.github/workflows/test-unix-mono.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   unix-mono:
-    name: Mono ${{ inputs.os }}-${{ inputs.architecture }} ${{ inputs.target_framework }} ${{ inputs.build_configuration }}
+    name: ${{ inputs.build_configuration }}
     runs-on: ${{inputs.image}}
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test-windows-dotnet.yml
+++ b/.github/workflows/test-windows-dotnet.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   unix-net:
-    name: .NET ${{ inputs.architecture }} ${{ inputs.target_framework }} ${{ inputs.build_configuration }}
+    name: ${{ inputs.build_configuration }}
     runs-on: windows-latest
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test-windows-framework.yml
+++ b/.github/workflows/test-windows-framework.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   windows-net-framework:
-    name: .NET FX ${{ inputs.architecture }} ${{ inputs.target_framework }} ${{ inputs.build_configuration }}
+    name: ${{ inputs.build_configuration }}
     runs-on: windows-2019
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test-windows-mono.yml
+++ b/.github/workflows/test-windows-mono.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   windows-mono:
-    name: Mono ${{ inputs.architecture }} ${{ inputs.target_framework }} ${{ inputs.build_configuration }}
+    name: ${{ inputs.build_configuration }}
     runs-on: windows-latest
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
   # Ideally we should be able to build binaries on Ubuntu to all platforms to test
   # and have a job that will create binaries on each platform and compare the output dll's
   build-binaries:
-    name: Build Binaries
+    name: Build
     needs: variables
     strategy:
       matrix:
@@ -86,7 +86,7 @@ jobs:
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
   windows-dotnet:
-    name: Windows .NET x86/x64
+    name: Win .NET
     needs: [variables, build-binaries]
     strategy:
       fail-fast: false
@@ -103,7 +103,7 @@ jobs:
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
   windows-framework:
-    name: Windows .NET Framework x86/x64
+    name: Win Fwk
     needs: [variables, build-binaries]
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
   windows-mono:
-    name: Windows Mono x86/x64
+    name: Win Mono
     needs: [variables, build-binaries]
     strategy:
       fail-fast: false
@@ -137,7 +137,7 @@ jobs:
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
   ubuntu-macos-x64-dotnet:
-    name: Ubuntu/MacOS .NET x64
+    name: Unix .NET
     needs: [variables, build-binaries]
     strategy:
       fail-fast: false
@@ -157,7 +157,7 @@ jobs:
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
   ubuntu-macos-x64-mono:
-    name: Ubuntu/MacOS Mono x64
+    name: Unix Mono
     needs: [variables, build-binaries]
     strategy:
       fail-fast: false
@@ -176,122 +176,16 @@ jobs:
       build_configuration: ${{matrix.build_configuration}}
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
-  macos-rosetta-dotnet:
-    name: MacOS .NET Rosetta 2
-    needs: [variables, build-binaries]
-    if: ${{needs.variables.outputs.EXPERIMENTAL == 'true'}}
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ { os: 'macos-arm64', code: 'macos-14' } ]
-        architecture: ['x64']
-        target_framework: ${{fromJson((needs.variables.outputs.PARALLEL == 'true' && needs.variables.outputs.DOTNET_TARGET_FRAMEWORKS_MACOS_ARM64) || '[""]')}}
-        build_configuration: ${{fromJson(needs.variables.outputs.BUILD_CONFIGURATIONS)}}
-    uses: ./.github/workflows/test-unix-dotnet.yml
-    with:
-      os: ${{matrix.image.os}}
-      image: ${{matrix.image.code}}
-      architecture: ${{matrix.architecture}}
-      target_framework: ${{matrix.target_framework }}
-      target_framework_array: ${{needs.variables.outputs.DOTNET_TARGET_FRAMEWORKS_MACOS_ARM64}}
-      build_configuration: ${{matrix.build_configuration}}
-      manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
-
-  macos-rosetta-mono:
-    name: MacOS Mono Rosetta 2
-    needs: [variables, build-binaries]
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ { os: 'macos-arm64', code: 'macos-14' } ]
-        architecture: ['x64']
-        target_framework: ${{fromJson((needs.variables.outputs.PARALLEL == 'true' && needs.variables.outputs.FRAMEWORK_TARGET_FRAMEWORKS) || '[""]')}}
-        build_configuration: ${{fromJson(needs.variables.outputs.BUILD_CONFIGURATIONS)}}
-    uses: ./.github/workflows/test-unix-mono.yml
-    with:
-      os: ${{matrix.image.os}}
-      image: ${{matrix.image.code}}
-      architecture: ${{matrix.architecture}}
-      target_framework: ${{matrix.target_framework}}
-      target_framework_array: ${{needs.variables.outputs.FRAMEWORK_TARGET_FRAMEWORKS}}
-      build_configuration: ${{matrix.build_configuration}}
-      manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
-
-  ubuntu-arm64-dotnet:
-    name: Ubuntu .NET arm64
-    needs: [variables, build-binaries]
-    if: ${{needs.variables.outputs.EXPERIMENTAL == 'true'}}
-    strategy:
-      fail-fast: false
-      matrix:
-        target_framework: ${{fromJson((needs.variables.outputs.PARALLEL == 'true' && needs.variables.outputs.DOTNET_TARGET_FRAMEWORKS_MACOS_ARM64) || '[""]')}}
-        build_configuration: ${{fromJson(needs.variables.outputs.BUILD_CONFIGURATIONS)}}
-    uses: ./.github/workflows/test-qemu-dotnet.yml
-    with:
-      target_framework: ${{matrix.target_framework}}
-      #target_framework_array: ${{fromJson(needs.variables.outputs.DOTNET_TARGET_FRAMEWORKS_MACOS_ARM64)}}
-      build_configuration: ${{ matrix.build_configuration }}
-      run_settings_args: 'NUnit.DefaultTestNamePattern="{C}:{m}{a}" RunConfiguration.TargetPlatform=arm64'
-      #manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
-      experimental: true
-
-  ubuntu-arm64-mono:
-    name: Ubuntu .NET arm64
-    needs: [variables, build-binaries]
-    if: ${{needs.variables.outputs.EXPERIMENTAL == 'true'}}
-    strategy:
-      fail-fast: false
-      matrix:
-        target_framework: ${{fromJson((needs.variables.outputs.PARALLEL == 'true' && needs.variables.outputs.FRAMEWORK_TARGET_FRAMEWORKS) || '[""]')}}
-        build_configuration: ${{fromJson(needs.variables.outputs.BUILD_CONFIGURATIONS)}}
-    uses: ./.github/workflows/test-qemu-mono.yml
-    with:
-      target_framework: ${{matrix.target_framework}}
-      #target_framework_array: ${{fromJson(needs.variables.outputs.FRAMEWORK_TARGET_FRAMEWORKS)}}
-      build_configuration: ${{matrix.build_configuration}}
-      run_settings_args: 'NUnit.DefaultTestNamePattern="{C}:{m}{a}" RunConfiguration.TargetPlatform=arm64'
-      #manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
-      experimental: true
-
-  macos-arm64-dotnet:
-    name: MacOS .NET arm64
-    needs: [variables, build-binaries]
-    if: ${{needs.variables.outputs.EXPERIMENTAL == 'true'}}
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ { os: 'macos-arm64', code: 'macos-14' } ]
-        architecture: ['arm64']
-        target_framework: ${{fromJson((needs.variables.outputs.PARALLEL == 'true' && needs.variables.outputs.DOTNET_TARGET_FRAMEWORKS_MACOS_ARM64) || '[""]')}}
-        build_configuration: ${{fromJson(needs.variables.outputs.BUILD_CONFIGURATIONS)}}
-    uses: ./.github/workflows/test-unix-dotnet.yml
-    with:
-      os: ${{ matrix.image.os }}
-      image: ${{ matrix.image.code }}
-      architecture: ${{ matrix.architecture }}
-      target_framework: ${{ matrix.target_framework }}
-      target_framework_array: ${{fromJson(needs.variables.outputs.DOTNET_TARGET_FRAMEWORKS_MACOS_ARM64)}}
-      build_configuration: ${{matrix.build_configuration}}
-      manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
-      experimental: true
 
   test-results:
-    name: Download and Upload Test Results
-    needs: [windows-dotnet, windows-framework, windows-mono, ubuntu-macos-x64-dotnet, ubuntu-macos-x64-mono, macos-rosetta-dotnet, macos-rosetta-mono]
+    name: Test Results
+    needs: [windows-dotnet, windows-framework, windows-mono, ubuntu-macos-x64-dotnet, ubuntu-macos-x64-mono]
     if: always()
     uses: ./.github/workflows/test-result-upload.yml
 
-  test-results-experimental:
-    name: Download and Upload Test Results (Experimental)
-    needs: [ubuntu-arm64-dotnet, ubuntu-arm64-mono, macos-arm64-dotnet]
-    if: ${{needs.variables.outputs.EXPERIMENTAL == 'true' && always()}}
-    uses: ./.github/workflows/test-result-upload.yml
-    with:
-      experimental: true
-
   cleanup-build-output:
     name: Cleanup Build Output
-    needs: [test-results, test-results-experimental]
+    needs: [test-results]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -301,7 +195,3 @@ jobs:
       - uses: joutvhu/delete-artifact@v2
         with:
           pattern: test-results-*
-      - uses: joutvhu/delete-artifact@v2
-        if: ${{needs.variables.outputs.PARALLEL == 'true'}}
-        with:
-          pattern: experimental-test-results-*


### PR DESCRIPTION
## Summary
- shrink workflow job names
- drop unused experimental jobs
- use build configuration as job name in templates

## Testing
- `bash test.sh` *(fails: dotnet: command not found)*