### PR TITLE
Add missing tests for AccessTools cache and extensions

### DIFF
--- a/HarmonyTests/Tools/TestAccessTools.cs
+++ b/HarmonyTests/Tools/TestAccessTools.cs
@@ -125,6 +125,25 @@ namespace HarmonyLibTests.Tools
 			Test_AccessTools_TypeByName_CurrentAssemblies();
 		}
 
+		[Test, NonParallelizable]
+		public void Test_AccessTools_TypeSearch_CacheInvalidation()
+		{
+			AccessTools.ClearTypeSearchCache();
+
+			var search = new Regex("HarmonyTestsDummyAssemblyD\\.Class1$");
+			Assert.Null(AccessTools.TypeSearch(search));
+
+			var dummy = DefineAssembly("HarmonyTestsDummyAssemblyD",
+					  module => module.DefineType("HarmonyTestsDummyAssemblyD.Class1", TypeAttributes.Public));
+			SaveAssembly(dummy);
+			TestTools.RunInIsolationContext(ctx => ctx.AssemblyLoad("HarmonyTestsDummyAssemblyD"));
+
+			Assert.Null(AccessTools.TypeSearch(search));
+
+			AccessTools.ClearTypeSearchCache();
+			Assert.NotNull(AccessTools.TypeSearch(search));
+		}
+
 		static void TestTypeByNameWithInvalidAssembly(ITestIsolationContext context)
 		{
 			// HarmonyTestsDummyAssemblyB has a dependency on HarmonyTestsDummyAssemblyA, but we've ensured that

--- a/HarmonyTests/Tools/TestAccessToolsExtensions.cs
+++ b/HarmonyTests/Tools/TestAccessToolsExtensions.cs
@@ -1,0 +1,37 @@
+using HarmonyLib;
+using HarmonyLibTests.Assets;
+using NUnit.Framework;
+using System.Linq;
+using System.Reflection;
+
+namespace HarmonyLibTests.Tools
+{
+	[TestFixture, NonParallelizable]
+	public class Test_AccessToolsExtensions : TestLogger
+	{
+		[Test]
+		public void Test_InnerTypes()
+		{
+			var inner = typeof(AccessToolsClass).InnerTypes().ToArray();
+			Assert.Contains(typeof(AccessToolsClass).GetNestedType("Inner", BindingFlags.NonPublic), inner);
+			Assert.Contains(typeof(AccessToolsClass).GetNestedType("InnerStruct", BindingFlags.NonPublic), inner);
+		}
+
+		[Test]
+		public void Test_FindIncludingBaseTypes()
+		{
+			var field = typeof(AccessToolsSubClass).FindIncludingBaseTypes(t => t.GetField("field1", AccessTools.all));
+			Assert.NotNull(field);
+			Assert.AreEqual(typeof(AccessToolsClass), field.DeclaringType);
+		}
+
+		[Test]
+		public void Test_FindIncludingInnerTypes()
+		{
+			var type = typeof(AccessToolsClass).FindIncludingInnerTypes(t => t.Name == "InnerStruct" ? t : null);
+			Assert.NotNull(type);
+			Assert.AreEqual("InnerStruct", type.Name);
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary
- add test ensuring TypeSearch cache invalidation works
- add new test file for AccessTools extension helpers

## Testing
- `dotnet test HarmonyTests/HarmonyTests.csproj --framework net9.0 --runtime linux-x64 --no-build --filter "FullyQualifiedName~Test_AccessTools_TypeSearch_CacheInvalidation|FullyQualifiedName~Test_AccessToolsExtensions" --logger "console;verbosity=minimal"`