### PR TITLE
Add LocalBuilder checks to `CodeInstructionExtensions.LocalIndex`

### DIFF
--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -578,7 +578,9 @@ namespace HarmonyLib
 				return 2;
 			else if (code.opcode == OpCodes.Ldloc_3 || code.opcode == OpCodes.Stloc_3)
 				return 3;
-			else if (code.opcode == OpCodes.Ldloc_S || code.opcode == OpCodes.Ldloc)
+			if (code.operand is LocalBuilder localBuilder)
+				return localBuilder.LocalIndex;
+			if (code.opcode == OpCodes.Ldloc_S || code.opcode == OpCodes.Ldloc)
 				return Convert.ToInt32(code.operand);
 			else if (code.opcode == OpCodes.Stloc_S || code.opcode == OpCodes.Stloc)
 				return Convert.ToInt32(code.operand);

--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -578,14 +578,24 @@ namespace HarmonyLib
 				return 2;
 			else if (code.opcode == OpCodes.Ldloc_3 || code.opcode == OpCodes.Stloc_3)
 				return 3;
-			if (code.operand is LocalBuilder localBuilder)
-				return localBuilder.LocalIndex;
-			if (code.opcode == OpCodes.Ldloc_S || code.opcode == OpCodes.Ldloc)
+			else if (code.opcode == OpCodes.Ldloc_S || code.opcode == OpCodes.Ldloc)
+			{
+				if (code.operand is LocalBuilder localBuilder)
+					return localBuilder.LocalIndex;
 				return Convert.ToInt32(code.operand);
+			}
 			else if (code.opcode == OpCodes.Stloc_S || code.opcode == OpCodes.Stloc)
+			{
+				if (code.operand is LocalBuilder localBuilder)
+					return localBuilder.LocalIndex;
 				return Convert.ToInt32(code.operand);
+			}
 			else if (code.opcode == OpCodes.Ldloca_S || code.opcode == OpCodes.Ldloca)
+			{
+				if (code.operand is LocalBuilder localBuilder)
+					return localBuilder.LocalIndex;
 				return Convert.ToInt32(code.operand);
+			}
 			else
 				throw new ArgumentException("Instruction is not a load or store", nameof(code));
 		}


### PR DESCRIPTION
Problem: When calling `CodeInstructionExtensions.LocalIndex`, sometimes the operand is a LocalBuilder, currently the code does not handle this.

I came across this when I was trying to get the local index from a Stloc_S but the operand was not an int but actually a LocalBuilder. In that case you need to convert operand to LocalBuilder and take the LocalIndex from it. It makes sense for this extension to do this otherwise you need to do it yourself outside.