### PR TITLE
Implement more MethodType cases

### DIFF
--- a/Harmony/Internal/PatchTools.cs
+++ b/Harmony/Internal/PatchTools.cs
@@ -147,12 +147,105 @@ namespace HarmonyLib
 						return AccessTools.EnumeratorMoveNext(enumMethod);
 
 #if NET45_OR_GREATER || NETSTANDARD || NETCOREAPP
-					case MethodType.Async:
+                                       case MethodType.Async:
+                                               if (string.IsNullOrEmpty(attr.methodName))
+                                                       return null;
+                                               var asyncMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
+                                               return AccessTools.AsyncMoveNext(asyncMethod);
+#endif
+					case MethodType.Finalizer:
+						return AccessTools.DeclaredFinalizer(attr.declaringType);
+
+					case MethodType.EventAdd:
 						if (string.IsNullOrEmpty(attr.methodName))
 							return null;
-						var asyncMethod = AccessTools.DeclaredMethod(attr.declaringType, attr.methodName, attr.argumentTypes);
-						return AccessTools.AsyncMoveNext(asyncMethod);
-#endif
+						return AccessTools.DeclaredEventAdder(attr.declaringType, attr.methodName);
+
+					case MethodType.EventRemove:
+						if (string.IsNullOrEmpty(attr.methodName))
+							return null;
+						return AccessTools.DeclaredEventRemover(attr.declaringType, attr.methodName);
+
+					case MethodType.OperatorImplicit:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Implicit", attr.argumentTypes);
+
+					case MethodType.OperatorExplicit:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Explicit", attr.argumentTypes);
+
+					case MethodType.OperatorUnaryPlus:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_UnaryPlus", attr.argumentTypes);
+
+					case MethodType.OperatorUnaryNegation:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_UnaryNegation", attr.argumentTypes);
+
+					case MethodType.OperatorLogicalNot:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_LogicalNot", attr.argumentTypes);
+
+					case MethodType.OperatorOnesComplement:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_OnesComplement", attr.argumentTypes);
+
+					case MethodType.OperatorIncrement:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Increment", attr.argumentTypes);
+
+					case MethodType.OperatorDecrement:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Decrement", attr.argumentTypes);
+
+					case MethodType.OperatorTrue:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_True", attr.argumentTypes);
+
+					case MethodType.OperatorFalse:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_False", attr.argumentTypes);
+
+					case MethodType.OperatorAddition:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Addition", attr.argumentTypes);
+
+					case MethodType.OperatorSubtraction:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Subtraction", attr.argumentTypes);
+
+					case MethodType.OperatorMultiply:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Multiply", attr.argumentTypes);
+
+					case MethodType.OperatorDivision:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Division", attr.argumentTypes);
+
+					case MethodType.OperatorModulus:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Modulus", attr.argumentTypes);
+
+					case MethodType.OperatorBitwiseAnd:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_BitwiseAnd", attr.argumentTypes);
+
+					case MethodType.OperatorBitwiseOr:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_BitwiseOr", attr.argumentTypes);
+
+					case MethodType.OperatorExclusiveOr:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_ExclusiveOr", attr.argumentTypes);
+
+					case MethodType.OperatorLeftShift:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_LeftShift", attr.argumentTypes);
+
+					case MethodType.OperatorRightShift:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_RightShift", attr.argumentTypes);
+
+					case MethodType.OperatorEquality:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Equality", attr.argumentTypes);
+
+					case MethodType.OperatorInequality:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Inequality", attr.argumentTypes);
+
+					case MethodType.OperatorGreaterThan:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_GreaterThan", attr.argumentTypes);
+
+					case MethodType.OperatorLessThan:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_LessThan", attr.argumentTypes);
+
+					case MethodType.OperatorGreaterThanOrEqual:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_GreaterThanOrEqual", attr.argumentTypes);
+
+					case MethodType.OperatorLessThanOrEqual:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_LessThanOrEqual", attr.argumentTypes);
+
+					case MethodType.OperatorComma:
+						return AccessTools.DeclaredMethod(attr.declaringType, "op_Comma", attr.argumentTypes);
 				}
 			}
 			catch (AmbiguousMatchException ex)

--- a/Harmony/Tools/AccessTools.cs
+++ b/Harmony/Tools/AccessTools.cs
@@ -498,6 +498,130 @@ namespace HarmonyLib
 		///
 		public static MethodInfo IndexerSetter(Type type, Type[] parameters = null) => Indexer(type, parameters)?.GetSetMethod(true);
 
+		/// <summary>Gets the reflection information for a directly declared event</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>An event or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static EventInfo DeclaredEvent(Type type, string name)
+		{
+			if (type is null)
+			{
+				FileLog.Debug("AccessTools.DeclaredEvent: type is null");
+				return null;
+			}
+			if (string.IsNullOrEmpty(name))
+			{
+				FileLog.Debug("AccessTools.DeclaredEvent: name is null/empty");
+				return null;
+			}
+			var eventInfo = type.GetEvent(name, allDeclared);
+			if (eventInfo is null)
+				FileLog.Debug($"AccessTools.DeclaredEvent: Could not find event for type {type} and name {name}");
+			return eventInfo;
+		}
+
+		/// <summary>Gets the reflection information for a directly declared event</summary>
+		/// <param name="typeColonName">The member in the form <c>TypeFullName:MemberName</c>, where TypeFullName matches the form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <returns>An event or null when the event cannot be found</returns>
+		///
+		public static EventInfo DeclaredEvent(string typeColonName)
+		{
+			var info = Tools.TypColonName(typeColonName);
+			var eventInfo = info.type.GetEvent(info.name, allDeclared);
+			if (eventInfo is null)
+				FileLog.Debug($"AccessTools.DeclaredEvent: Could not find event for type {info.type} and name {info.name}");
+			return eventInfo;
+		}
+
+		/// <summary>Gets the reflection information for an event by searching the type and all its super types</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>An event or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static EventInfo Event(Type type, string name)
+		{
+			if (type is null)
+			{
+				FileLog.Debug("AccessTools.Event: type is null");
+				return null;
+			}
+			if (string.IsNullOrEmpty(name))
+			{
+				FileLog.Debug("AccessTools.Event: name is null/empty");
+				return null;
+			}
+			var eventInfo = FindIncludingBaseTypes(type, t => t.GetEvent(name, all));
+			if (eventInfo is null)
+				FileLog.Debug($"AccessTools.Event: Could not find event for type {type} and name {name}");
+			return eventInfo;
+		}
+
+		/// <summary>Gets the reflection information for an event by searching the type and all its super types</summary>
+		/// <param name="typeColonName">The member in the form <c>TypeFullName:MemberName</c>, where TypeFullName matches the form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <returns>An event or null when the event cannot be found</returns>
+		///
+		public static EventInfo Event(string typeColonName)
+		{
+			var info = Tools.TypColonName(typeColonName);
+			var eventInfo = FindIncludingBaseTypes(info.type, t => t.GetEvent(info.name, all));
+			if (eventInfo is null)
+				FileLog.Debug($"AccessTools.Event: Could not find event for type {info.type} and name {info.name}");
+			return eventInfo;
+		}
+
+		/// <summary>Gets the reflection information for the add method of a directly declared event</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo DeclaredEventAdder(Type type, string name) => DeclaredEvent(type, name)?.GetAddMethod(true);
+
+		/// <summary>Gets the reflection information for the add method of a directly declared event</summary>
+		/// <param name="typeColonName">The member in the form <c>TypeFullName:MemberName</c>, where TypeFullName matches the form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <returns>A method or null when the event cannot be found</returns>
+		///
+		public static MethodInfo DeclaredEventAdder(string typeColonName) => DeclaredEvent(typeColonName)?.GetAddMethod(true);
+
+		/// <summary>Gets the reflection information for the add method of an event by searching the type and all its super types</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo EventAdder(Type type, string name) => Event(type, name)?.GetAddMethod(true);
+
+		/// <summary>Gets the reflection information for the add method of an event by searching the type and all its super types</summary>
+		/// <param name="typeColonName">The member in the form <c>TypeFullName:MemberName</c>, where TypeFullName matches the form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <returns>A method or null when the event cannot be found</returns>
+		///
+		public static MethodInfo EventAdder(string typeColonName) => Event(typeColonName)?.GetAddMethod(true);
+
+		/// <summary>Gets the reflection information for the remove method of a directly declared event</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo DeclaredEventRemover(Type type, string name) => DeclaredEvent(type, name)?.GetRemoveMethod(true);
+
+		/// <summary>Gets the reflection information for the remove method of a directly declared event</summary>
+		/// <param name="typeColonName">The member in the form <c>TypeFullName:MemberName</c>, where TypeFullName matches the form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <returns>A method or null when the event cannot be found</returns>
+		///
+		public static MethodInfo DeclaredEventRemover(string typeColonName) => DeclaredEvent(typeColonName)?.GetRemoveMethod(true);
+
+		/// <summary>Gets the reflection information for the remove method of an event by searching the type and all its super types</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo EventRemover(Type type, string name) => Event(type, name)?.GetRemoveMethod(true);
+
+		/// <summary>Gets the reflection information for the remove method of an event by searching the type and all its super types</summary>
+		/// <param name="typeColonName">The member in the form <c>TypeFullName:MemberName</c>, where TypeFullName matches the form recognized by <a href="https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype">Type.GetType</a> like <c>Some.Namespace.Type</c>.</param>
+		/// <returns>A method or null when the event cannot be found</returns>
+		///
+		public static MethodInfo EventRemover(string typeColonName) => Event(typeColonName)?.GetRemoveMethod(true);
+
 		/// <summary>Gets the reflection information for a directly declared method</summary>
 		/// <param name="type">The class/type where the method is declared</param>
 		/// <param name="name">The name of the method (case sensitive)</param>
@@ -650,8 +774,8 @@ namespace HarmonyLib
 		/// <param name="method">Async method that creates the state machine internally</param>
 		/// <returns>The internal <see cref="IAsyncStateMachine.MoveNext"/> method of the async state machine or <b>null</b> if no valid async method is detected</returns>
 		///
-		public static MethodInfo AsyncMoveNext(MethodBase method)
-		{
+                public static MethodInfo AsyncMoveNext(MethodBase method)
+                {
 			if (method is null)
 			{
 				FileLog.Debug("AccessTools.AsyncMoveNext: method is null");
@@ -673,9 +797,21 @@ namespace HarmonyLib
 				return null;
 			}
 
-			return asyncMethodBody;
-		}
+                        return asyncMethodBody;
+                }
 #endif
+
+		/// <summary>Gets the reflection information for a finalizer</summary>
+		/// <param name="type">The class/type that defines the finalizer</param>
+		/// <returns>A method or null when type is null or when the finalizer cannot be found</returns>
+		///
+		public static MethodInfo Finalizer(Type type) => Method(type, "Finalize");
+
+		/// <summary>Gets the reflection information for a directly declared finalizer</summary>
+		/// <param name="type">The class/type that defines the finalizer</param>
+		/// <returns>A method or null when type is null or when the finalizer cannot be found</returns>
+		///
+		public static MethodInfo DeclaredFinalizer(Type type) => DeclaredMethod(type, "Finalize");
 
 		/// <summary>Gets the names of all method that are declared in a type</summary>
 		/// <param name="type">The declaring class/type</param>

--- a/Harmony/Tools/AccessToolsExtensions.cs
+++ b/Harmony/Tools/AccessToolsExtensions.cs
@@ -141,6 +141,60 @@ namespace HarmonyLib
 		///
 		public static MethodInfo IndexerSetter(this Type type, Type[] parameters = null) => AccessTools.IndexerSetter(type, parameters);
 
+		/// <summary>Gets the reflection information for a directly declared event</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>An event or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static EventInfo DeclaredEvent(this Type type, string name) => AccessTools.DeclaredEvent(type, name);
+
+		/// <summary>Gets the reflection information for an event by searching the type and all its super types</summary>
+		/// <param name="type">The class/type</param>
+		/// <param name="name">The name</param>
+		/// <returns>An event or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static EventInfo Event(this Type type, string name) => AccessTools.Event(type, name);
+
+		/// <summary>Gets the reflection information for the add method of a directly declared event</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo DeclaredEventAdder(this Type type, string name) => AccessTools.DeclaredEventAdder(type, name);
+
+		/// <summary>Gets the reflection information for the add method of an event by searching the type and all its super types</summary>
+		/// <param name="type">The class/type</param>
+		/// <param name="name">The name</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo EventAdder(this Type type, string name) => AccessTools.EventAdder(type, name);
+
+		/// <summary>Gets the reflection information for the remove method of a directly declared event</summary>
+		/// <param name="type">The class/type where the event is declared</param>
+		/// <param name="name">The name of the event (case sensitive)</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo DeclaredEventRemover(this Type type, string name) => AccessTools.DeclaredEventRemover(type, name);
+
+		/// <summary>Gets the reflection information for the remove method of an event by searching the type and all its super types</summary>
+		/// <param name="type">The class/type</param>
+		/// <param name="name">The name</param>
+		/// <returns>A method or null when type/name is null or when the event cannot be found</returns>
+		///
+		public static MethodInfo EventRemover(this Type type, string name) => AccessTools.EventRemover(type, name);
+
+		/// <summary>Gets the reflection information for a finalizer</summary>
+		/// <param name="type">The class/type that defines the finalizer</param>
+		/// <returns>A method or null when type is null or when the finalizer cannot be found</returns>
+		///
+		public static MethodInfo Finalizer(this Type type) => AccessTools.Finalizer(type);
+
+		/// <summary>Gets the reflection information for a directly declared finalizer</summary>
+		/// <param name="type">The class/type that defines the finalizer</param>
+		/// <returns>A method or null when type is null or when the finalizer cannot be found</returns>
+		///
+		public static MethodInfo DeclaredFinalizer(this Type type) => AccessTools.DeclaredFinalizer(type);
+
 		/// <summary>Gets the reflection information for a directly declared method</summary>
 		/// <param name="type">The class/type where the method is declared</param>
 		/// <param name="name">The name of the method (case sensitive)</param>


### PR DESCRIPTION
## Summary
- add event and finalizer helpers in `AccessTools`
- add extension methods for the new helpers
- map new `MethodType` cases in `PatchTools`

## Testing
- `dotnet format --no-restore`
- `dotnet test Harmony.sln -c Release -f net9.0 -r win-x64 --no-build --no-restore` *(fails: The argument HarmonyTests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_688b4282892883298548765368c51876