### PR TITLE
Use ToArray for patch serialization

### DIFF
--- a/Harmony/Serialization/PatchInfoSerialization.cs
+++ b/Harmony/Serialization/PatchInfoSerialization.cs
@@ -71,7 +71,8 @@ namespace HarmonyLib
 #endif
 			using var streamMemory = new MemoryStream();
 			binaryFormatter.Serialize(streamMemory, patchInfo);
-			return streamMemory.GetBuffer();
+			// Return only the used portion of the buffer
+			return streamMemory.ToArray();
 #if NET5_0_OR_GREATER
 			}
 			else


### PR DESCRIPTION
## Summary
- return only used bytes when serializing patch info by calling `ToArray()` instead of `GetBuffer()`

## Testing
- `dotnet restore Harmony.sln`
- `dotnet build Harmony.sln -c Release -f net9.0` *(fails: Assets file 'Lib.Harmony.Ref/obj/project.assets.json' doesn't have a target for 'net9.0')*

------
https://chatgpt.com/codex/tasks/task_e_688c713c2de883299bc18c0dd5168ce8