### PR TITLE
Fix Windows tests

### DIFF
--- a/.github/workflows/test-windows-framework.yml
+++ b/.github/workflows/test-windows-framework.yml
@@ -46,7 +46,7 @@ env:
 jobs:
   windows-net-framework:
     name: ${{ inputs.build_configuration }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     continue-on-error: ${{inputs.experimental}}
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
- update Windows CI image to windows-2022

## Testing
- `dotnet test HarmonyTests/HarmonyTests.csproj -c Debug -f net9.0 --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c758f34848329b20cbf5d52c64174