### PR TITLE
Add macOS arm64 Mono platform test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,9 +177,30 @@ jobs:
       manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
 
 
+  macos-arm64-mono:
+    name: macOS Mono ${{ matrix.architecture }}${{ matrix.build_configuration && '' }}
+    needs: [variables, build-binaries]
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ { os: 'macos-arm64', code: 'macos-14' } ]
+        architecture: ['arm64']
+        target_framework: ${{fromJson((needs.variables.outputs.PARALLEL == 'true' && needs.variables.outputs.FRAMEWORK_TARGET_FRAMEWORKS) || '[""]')}}
+        build_configuration: ${{fromJson(needs.variables.outputs.BUILD_CONFIGURATIONS)}}
+    uses: ./.github/workflows/test-unix-mono.yml
+    with:
+      os: ${{matrix.image.os}}
+      image: ${{matrix.image.code}}
+      architecture: ${{matrix.architecture}}
+      target_framework: ${{matrix.target_framework}}
+      target_framework_array: ${{needs.variables.outputs.FRAMEWORK_TARGET_FRAMEWORKS}}
+      build_configuration: ${{matrix.build_configuration}}
+      manual_build: ${{needs.variables.outputs.PREBUILD != 'true'}}
+
+
   test-results:
     name: Test Results
-    needs: [windows-dotnet, windows-framework, windows-mono, ubuntu-macos-x64-dotnet, ubuntu-macos-x64-mono]
+    needs: [windows-dotnet, windows-framework, windows-mono, ubuntu-macos-x64-dotnet, ubuntu-macos-x64-mono, macos-arm64-mono]
     if: always()
     uses: ./.github/workflows/test-result-upload.yml
 


### PR DESCRIPTION
## Summary
- add macOS Mono arm64 job to CI
- include arm64 Mono job in test result collection

## Testing
- `dotnet format Harmony.sln --no-restore --verbosity diagnostic`
- `dotnet test HarmonyTests/HarmonyTests.csproj -c Release -f net9.0`


------
https://chatgpt.com/codex/tasks/task_e_688e1ce066d48329a000897fd1d5b3ac