### PR TITLE
Build and test using packaged Harmony

### DIFF
--- a/.github/actions/test-execute-test/action.yml
+++ b/.github/actions/test-execute-test/action.yml
@@ -61,11 +61,25 @@ runs:
         "target_frameworks=$target_frameworks" | Out-File -FilePath $env:GITHUB_OUTPUT -Append;
       shell: pwsh
 
+    - name: Download NuGet package
+      uses: actions/download-artifact@v4
+      with:
+        name: nupkg-${{inputs.build_configuration}}
+        path: nupkg
+
+    - name: Use NuGet package
+      run: |
+        $libCsproj = Join-Path $env:GITHUB_WORKSPACE 'Lib.Harmony' 'Lib.Harmony.csproj'
+        dotnet remove HarmonyTests/HarmonyTests.csproj reference $libCsproj
+        dotnet add HarmonyTests/HarmonyTests.csproj package Lib.Harmony --no-restore
+        dotnet restore HarmonyTests/HarmonyTests.csproj --source (Join-Path $env:GITHUB_WORKSPACE 'nupkg')
+      shell: pwsh
+
     - name: Build if required
       if: ${{inputs.manual_build == 'true'}}
       run: |
         foreach ($target_framework in ConvertFrom-Json "${{steps.test-args.outputs.target_frameworks}}") {
-          dotnet build HarmonyTests/HarmonyTests.csproj -c ${{inputs.build_configuration}} -f $target_framework;
+          dotnet build HarmonyTests/HarmonyTests.csproj -c ${{inputs.build_configuration}} -f $target_framework --no-restore;
         }
       shell: pwsh
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -57,6 +57,17 @@ jobs:
             dotnet build -c ${{inputs.build_configuration}} Harmony.sln
           fi
 
+      - name: Pack NuGet
+        if: ${{inputs.publish}}
+        run: dotnet pack Lib.Harmony/Lib.Harmony.csproj -c ${{inputs.build_configuration}} --no-build -o nupkg
+
+      - name: Upload NuGet Package
+        if: ${{inputs.publish}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg-${{inputs.build_configuration}}
+          path: nupkg/*.nupkg
+
       - name: Upload Test Build Output Cache
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- pack Harmony as a NuGet package during build and publish it as an artifact
- run tests against the packaged Harmony by replacing project reference

## Testing
- `dotnet format` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895334a19a88329ad3f0b71c756258d