### PR TITLE
Fix IL offset logging in debug output

### DIFF
--- a/Harmony/Internal/MethodCopier.cs
+++ b/Harmony/Internal/MethodCopier.cs
@@ -414,13 +414,14 @@ namespace HarmonyLib
 			if (debug == false)
 				return;
 
+			var codePos = emitter.CurrentPos();
 			emitter.Variables().Do(v => FileLog.LogIL(v));
-			FileLog.LogILComment(emitter.CurrentPos(), "start original");
+			FileLog.LogILComment(codePos, "start original");
 
 			codeInstructions.Do(codeInstruction =>
 			{
-				codeInstruction.labels.Do(label => FileLog.LogIL(emitter.CurrentPos(), label));
-				codeInstruction.blocks.Do(block => FileLog.LogILBlockBegin(emitter.CurrentPos(), block));
+				codeInstruction.labels.Do(label => FileLog.LogIL(codePos, label));
+				codeInstruction.blocks.Do(block => FileLog.LogILBlockBegin(codePos, block));
 
 				var code = codeInstruction.opcode;
 				var operand = codeInstruction.operand;
@@ -428,19 +429,20 @@ namespace HarmonyLib
 				switch (code.OperandType)
 				{
 					case OperandType.InlineNone:
-						FileLog.LogIL(emitter.CurrentPos(), code);
+						FileLog.LogIL(codePos, code);
 						break;
 
 					case OperandType.InlineSig:
-						FileLog.LogIL(emitter.CurrentPos(), code, (ICallSiteGenerator)operand);
+						FileLog.LogIL(codePos, code, (ICallSiteGenerator)operand);
 						break;
 
 					default:
-						FileLog.LogIL(emitter.CurrentPos(), code, operand);
+						FileLog.LogIL(codePos, code, operand);
 						break;
 				}
 
-				codeInstruction.blocks.Do(block => FileLog.LogILBlockEnd(emitter.CurrentPos(), block));
+				codeInstruction.blocks.Do(block => FileLog.LogILBlockEnd(codePos, block));
+				codePos += codeInstruction.GetSize();
 			});
 		}
 

--- a/Harmony/Internal/MethodCreatorTools.cs
+++ b/Harmony/Internal/MethodCreatorTools.cs
@@ -560,12 +560,13 @@ namespace HarmonyLib
 
 		internal static void LogCodes(this MethodCreator _, Emitter emitter, List<CodeInstruction> codeInstructions)
 		{
+			var codePos = emitter.CurrentPos();
 			emitter.Variables().Do(v => FileLog.LogIL(v));
 
 			codeInstructions.Do(codeInstruction =>
 			{
-				codeInstruction.labels.Do(label => FileLog.LogIL(emitter.CurrentPos(), label));
-				codeInstruction.blocks.Do(block => FileLog.LogILBlockBegin(emitter.CurrentPos(), block));
+				codeInstruction.labels.Do(label => FileLog.LogIL(codePos, label));
+				codeInstruction.blocks.Do(block => FileLog.LogILBlockBegin(codePos, block));
 
 				var code = codeInstruction.opcode;
 				var operand = codeInstruction.operand;
@@ -575,21 +576,22 @@ namespace HarmonyLib
 					case OperandType.InlineNone:
 						var comment = codeInstruction.IsAnnotation();
 						if (comment != null)
-							FileLog.LogILComment(emitter.CurrentPos(), comment);
+							FileLog.LogILComment(codePos, comment);
 						else
-							FileLog.LogIL(emitter.CurrentPos(), code);
+							FileLog.LogIL(codePos, code);
 						break;
 
 					case OperandType.InlineSig:
-						FileLog.LogIL(emitter.CurrentPos(), code, (ICallSiteGenerator)operand);
+						FileLog.LogIL(codePos, code, (ICallSiteGenerator)operand);
 						break;
 
 					default:
-						FileLog.LogIL(emitter.CurrentPos(), code, operand);
+						FileLog.LogIL(codePos, code, operand);
 						break;
 				}
 
-				codeInstruction.blocks.Do(block => FileLog.LogILBlockEnd(emitter.CurrentPos(), block));
+				codeInstruction.blocks.Do(block => FileLog.LogILBlockEnd(codePos, block));
+				codePos += codeInstruction.GetSize();
 			});
 
 			FileLog.FlushBuffer();

--- a/Harmony/Tools/Extensions.cs
+++ b/Harmony/Tools/Extensions.cs
@@ -293,23 +293,64 @@ namespace HarmonyLib
 
 		static readonly HashSet<OpCode> constantLoadingCodes =
 		[
-			OpCodes.Ldc_I4_M1,
-			OpCodes.Ldc_I4_0,
-			OpCodes.Ldc_I4_1,
-			OpCodes.Ldc_I4_2,
-			OpCodes.Ldc_I4_3,
-			OpCodes.Ldc_I4_4,
-			OpCodes.Ldc_I4_5,
-			OpCodes.Ldc_I4_6,
-			OpCodes.Ldc_I4_7,
-			OpCodes.Ldc_I4_8,
-			OpCodes.Ldc_I4,
-			OpCodes.Ldc_I4_S,
-			OpCodes.Ldc_I8,
-			OpCodes.Ldc_R4,
-			OpCodes.Ldc_R8,
-			OpCodes.Ldstr
+		OpCodes.Ldc_I4_M1,
+OpCodes.Ldc_I4_0,
+OpCodes.Ldc_I4_1,
+OpCodes.Ldc_I4_2,
+OpCodes.Ldc_I4_3,
+OpCodes.Ldc_I4_4,
+OpCodes.Ldc_I4_5,
+OpCodes.Ldc_I4_6,
+OpCodes.Ldc_I4_7,
+OpCodes.Ldc_I4_8,
+OpCodes.Ldc_I4,
+OpCodes.Ldc_I4_S,
+OpCodes.Ldc_I8,
+OpCodes.Ldc_R4,
+OpCodes.Ldc_R8,
+OpCodes.Ldstr
 		];
+
+		internal static int GetSize(this CodeInstruction instruction)
+		{
+			var size = instruction.opcode.Size;
+
+			switch (instruction.opcode.OperandType)
+			{
+				case OperandType.InlineSwitch:
+					size += (1 + ((Array)instruction.operand).Length) * 4;
+					break;
+
+				case OperandType.InlineI8:
+				case OperandType.InlineR:
+					size += 8;
+					break;
+
+				case OperandType.InlineBrTarget:
+				case OperandType.InlineField:
+				case OperandType.InlineI:
+				case OperandType.InlineMethod:
+				case OperandType.InlineSig:
+				case OperandType.InlineString:
+				case OperandType.InlineTok:
+				case OperandType.InlineType:
+				case OperandType.ShortInlineR:
+					size += 4;
+					break;
+
+				case OperandType.InlineVar:
+					size += 2;
+					break;
+
+				case OperandType.ShortInlineBrTarget:
+				case OperandType.ShortInlineI:
+				case OperandType.ShortInlineVar:
+					size += 1;
+					break;
+			}
+
+			return size;
+		}
 
 		/// <summary>Returns if an <see cref="OpCode"/> is initialized and valid</summary>
 		/// <param name="code">The <see cref="OpCode"/></param>


### PR DESCRIPTION
## Summary
- track emitted IL offsets when logging so each instruction shows incrementing `IL_####`
- compute instruction size through new `GetSize` helper for `CodeInstruction`

## Testing
- `dotnet format Harmony.sln --include Harmony/Internal/MethodCopier.cs Harmony/Internal/MethodCreatorTools.cs Harmony/Tools/Extensions.cs`
- `dotnet test HarmonyTests/HarmonyTests.csproj -f net9.0 -c Release --arch x64` *(fails: DynamicMethodDefinition/Mono.Cecil not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6b26ff1c8329b5e8075e57278ae8