### PR TITLE
Improve PatchCategory/UnpatchCategory

### DIFF
--- a/Harmony/Public/Harmony.cs
+++ b/Harmony/Public/Harmony.cs
@@ -156,7 +156,7 @@ namespace HarmonyLib
 				var harmonyAttributes = HarmonyMethodExtensions.GetFromType(type);
 				if (harmonyAttributes.Count == 0) continue;
 				var containerAttributes = HarmonyMethod.Merge(harmonyAttributes);
-				string? category = containerAttributes.category;
+				var category = containerAttributes.category;
 				if (!string.IsNullOrEmpty(category))
 				{
 					if (!toBuild.TryGetValue(category, out var typeList))

--- a/HarmonyTests/Patching/CategoryPatches.cs
+++ b/HarmonyTests/Patching/CategoryPatches.cs
@@ -1,0 +1,89 @@
+using HarmonyLib;
+using NUnit.Framework;
+using System.Runtime.CompilerServices;
+
+namespace HarmonyLibTests.Patching
+{
+	[TestFixture, NonParallelizable]
+	public class CategoryPatches : TestLogger
+	{
+		[Test]
+		public void Test_HarmonyPatchAll()
+		{
+			var harmony = new Harmony("test");
+			harmony.PatchCategory("CategoryA");
+
+			Assert.AreEqual(2, Get1());
+			Assert.AreEqual(false, GetTrue());
+			Assert.AreEqual("Hello World", GetHelloWorld());
+			Assert.AreEqual(18, Multiply(3, 6));
+
+
+			harmony.PatchCategory("CategoryB");
+
+			Assert.AreEqual(2, Get1());
+			Assert.AreEqual(false, GetTrue());
+			Assert.AreEqual("Hello World!", GetHelloWorld());
+			Assert.AreEqual(36, Multiply(3, 6));
+
+			harmony.UnpatchCategory("CategoryA");
+
+			Assert.AreEqual(1, Get1());
+			Assert.AreEqual(true, GetTrue());
+			Assert.AreEqual("Hello World!", GetHelloWorld());
+			Assert.AreEqual(36, Multiply(3, 6));
+
+			harmony.UnpatchCategory("CategoryB");
+
+			Assert.AreEqual(1, Get1());
+			Assert.AreEqual(true, GetTrue());
+			Assert.AreEqual("Hello World", GetHelloWorld());
+			Assert.AreEqual(18, Multiply(3, 6));
+		}
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static int Get1() => 1;
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static bool GetTrue() => true;
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static string GetHelloWorld() => "Hello World";
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static int Multiply(int a, int b) => a * b;
+
+		[HarmonyPatch]
+		[HarmonyPatch(typeof(CategoryPatches))]
+		[HarmonyPatchCategory("CategoryA")]
+		static class CategoryAPatches
+		{
+			[HarmonyPatch(nameof(Get1)), HarmonyPrefix]
+			public static bool Get1Patch(ref int __result)
+			{
+				__result = 2;
+				return false;
+			}
+			[HarmonyPatch(nameof(GetTrue)), HarmonyPostfix]
+			public static void GetTruePatch(ref bool __result)
+			{
+				__result = false;
+			}
+		}
+
+		[HarmonyPatch]
+		[HarmonyPatchCategory("CategoryB")]
+		static class CategoryBPatches
+		{
+			[HarmonyPatch(typeof(CategoryPatches), nameof(GetHelloWorld)), HarmonyPostfix]
+			public static void GetHelloWorldPatch(ref string __result)
+			{
+				__result = __result + "!";
+			}
+			[HarmonyPatch(typeof(CategoryPatches), nameof(Multiply)), HarmonyPrefix]
+			public static void Multiply(ref int a)
+			{
+				a *= 2;
+			}
+		}
+	}
+}


### PR DESCRIPTION
The current implementation used in Harmony scans, for each call, every type in the assembly.

This implementation creates a cache for all categories on the first call for each assembly (using a ConditionalWeakTable per Assembly)
The cache for an assembly is basically a Dictionary<string, List<Type>>, where string is the category and List<Type> is the list of types that have the attribute applied.

Considering the caches are keyed to a specific assembly; I think things like dynamic types shouldn't cause any issues. 

I'm unsure of where to put the static AssemblyCachedCategories. It's currently a static field on Harmony; but maybe it should go to the HarmonySharedState instead?
