### PR TITLE
Internalize dependencies in merged packages

### DIFF
--- a/Harmony/ForwardingAttributes/Mono.Cecil.Cil.cs
+++ b/Harmony/ForwardingAttributes/Mono.Cecil.Cil.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.Cecil.Cil.Code))]

--- a/Harmony/ForwardingAttributes/Mono.Cecil.Mdb.cs
+++ b/Harmony/ForwardingAttributes/Mono.Cecil.Mdb.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.Cecil.Mdb.MdbReader))]

--- a/Harmony/ForwardingAttributes/Mono.Cecil.Pdb.cs
+++ b/Harmony/ForwardingAttributes/Mono.Cecil.Pdb.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.Cecil.Pdb.NativePdbReader))]

--- a/Harmony/ForwardingAttributes/Mono.Cecil.Rocks.cs
+++ b/Harmony/ForwardingAttributes/Mono.Cecil.Rocks.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.Cecil.Rocks.IILVisitor))]

--- a/Harmony/ForwardingAttributes/Mono.Cecil.cs
+++ b/Harmony/ForwardingAttributes/Mono.Cecil.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.Cecil.AssemblyAttributes))]

--- a/Harmony/ForwardingAttributes/Mono.Collections.Generic.cs
+++ b/Harmony/ForwardingAttributes/Mono.Collections.Generic.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.Collections.Generic.Collection<>))]

--- a/Harmony/ForwardingAttributes/Mono.CompilerServices.SymbolWriter.cs
+++ b/Harmony/ForwardingAttributes/Mono.CompilerServices.SymbolWriter.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(Mono.CompilerServices.SymbolWriter.AnonymousScopeEntry))]

--- a/Harmony/ForwardingAttributes/MonoMod.Utils.Cil.cs
+++ b/Harmony/ForwardingAttributes/MonoMod.Utils.Cil.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(MonoMod.Utils.Cil.CecilILGenerator))]

--- a/Harmony/ForwardingAttributes/MonoMod.Utils.cs
+++ b/Harmony/ForwardingAttributes/MonoMod.Utils.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD
+#if HARMONY_THIN && (NETFRAMEWORK || NETSTANDARD)
 using System.Runtime.CompilerServices;
 
 [assembly: TypeForwardedTo(typeof(MonoMod.Utils.DMDEmitDynamicMethodGenerator))]

--- a/Lib.Harmony.Ref/Lib.Harmony.Ref.csproj
+++ b/Lib.Harmony.Ref/Lib.Harmony.Ref.csproj
@@ -9,6 +9,7 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRefAssemblyToPackage</TargetsForTfmSpecificContentInPackage>
 
     <PackageId>Lib.Harmony.Ref</PackageId>
+    <DefineConstants>$(DefineConstants);HARMONY_THIN</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Lib.Harmony.Thin/Lib.Harmony.Thin.csproj
+++ b/Lib.Harmony.Thin/Lib.Harmony.Thin.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <PackageId>Lib.Harmony.Thin</PackageId>
     <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);HARMONY_THIN</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration.StartsWith('Release'))">

--- a/Lib.Harmony/Lib.Harmony.csproj
+++ b/Lib.Harmony/Lib.Harmony.csproj
@@ -12,6 +12,9 @@
   </PropertyGroup>
 
   <Import Project="..\Harmony\Harmony.projitems" Label="Shared" />
+	<ItemGroup>
+		<Compile Remove="..\Harmony\ForwardingAttributes\*.cs" />
+	</ItemGroup>
 
   <ItemGroup>
     <None Include="../_._" Pack="true" Visible="false" PackagePath="lib/netstandard2.0" />

--- a/Lib.Harmony/Lib.Harmony.csproj
+++ b/Lib.Harmony/Lib.Harmony.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <Import Project="..\Harmony\Harmony.projitems" Label="Shared" />
-	<ItemGroup>
-		<Compile Remove="..\Harmony\ForwardingAttributes\*.cs" />
-	</ItemGroup>
-
   <ItemGroup>
     <None Include="../_._" Pack="true" Visible="false" PackagePath="lib/netstandard2.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Exclude forwarded Mono.Cecil and related types when building merged package
- Revert ILRepack references from thin and ref variants

## Testing
- `dotnet format --verify-no-changes`
- `dotnet test HarmonyTests/HarmonyTests.csproj -c Release -f net9.0 --arch x64`


------
https://chatgpt.com/codex/tasks/task_e_68a6c507c30c832988a7151def02c9f0