### PR TITLE
Fix a bunch of Mono.Cecil's API being public in the merged version

### DIFF
--- a/Harmony/Internal/MethodCreatorTools.cs
+++ b/Harmony/Internal/MethodCreatorTools.cs
@@ -561,7 +561,7 @@ namespace HarmonyLib
 		internal static void LogCodes(this MethodCreator _, Emitter emitter, List<CodeInstruction> codeInstructions)
 		{
 			var codePos = emitter.CurrentPos();
-			emitter.Variables().Do(v => FileLog.LogIL(v));
+			emitter.Variables().Do(FileLog.LogIL);
 
 			codeInstructions.Do(codeInstruction =>
 			{

--- a/Harmony/Tools/FileLog.cs
+++ b/Harmony/Tools/FileLog.cs
@@ -231,7 +231,7 @@ namespace HarmonyLib
 		/// <param name="variable">The <see cref="Mono.Cecil.Cil.VariableDefinition"/> representing the local variable to log. Must not be <see
 		/// langword="null"/>.</param>
 		/// 
-		public static void LogIL(Mono.Cecil.Cil.VariableDefinition variable)
+		internal static void LogIL(Mono.Cecil.Cil.VariableDefinition variable)
 			=> LogBuffered(string.Format("{0}Local var {1}: {2}{3}", CodePos(0), variable.Index, variable.VariableType.FullName, variable.IsPinned ? "(pinned)" : ""));
 
 		/// <summary>Logs the intermediate language (IL) code at the specified position with the given label operand</summary>


### PR DESCRIPTION
Start of discussion on the discord server: https://discord.com/channels/131466550938042369/361891646742462467/1407848296734789822

Cecil's VariableDefinition was public in one FileLog method, so making that internal is the easiest fix.
The method could also be moved from FileLog to the MethodCreatorTools class, which is the only one that uses it, though.

With this change, everything Cecil is internal again:
<img width="710" height="485" alt="Screenshot of ILSpy with the merged 0Harmony.dll selected showing that all Cecil types are internal." src="https://github.com/user-attachments/assets/32ca14d4-28ed-4407-8ddf-24d4f25319f7" />
