### PR TITLE
Harden TRX cleanup to avoid result parsing errors

### DIFF
--- a/scripts/clean-trx-files.md
+++ b/scripts/clean-trx-files.md
@@ -20,8 +20,8 @@ lxml.etree.XMLSyntaxError: Extra content at the end of the document, line 1687, 
 The `scripts/clean-trx-files.py` script:
 
 1. **Sanitizes XML content** by properly escaping special characters in `<StdOut>` sections
-2. **Removes extra content** after the `</TestRun>` closing tag
-3. **Preserves XML validity** while cleaning problematic content
+2. **Trims extra content** after the final `</TestRun>` closing tag
+3. **Validates cleaned XML** and deletes files that remain invalid to prevent parser errors
 
 ## Integration
 


### PR DESCRIPTION
## Summary
- validate and sanitize TRX files using UTF-8/UTF-16 decoding
- trim trailing content and drop files that remain invalid
- document the cleanup process

## Testing
- `dotnet format scripts/clean-trx-files.py` *(fails: The file 'clean-trx-files.py' does not appear to be a valid project or solution file.)*
- `dotnet test -f net9.0 --arch x64`

------
https://chatgpt.com/codex/tasks/task_e_68a7a63fec6483299f5b3c9bcf2f9085