### PR TITLE
Generate RAG index for HarmonyBot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
-name: Build and Deploy Documentation
-
-on:
+name: Build and Deploy Documentation
+
+on:
   push:
     branches: [ master ]
     paths:
@@ -8,22 +8,41 @@ on:
       - 'Harmony/**'
       - 'scripts/generate_llm_pack.py'
       - '.github/workflows/docs.yml'
-
-jobs:
-  build:
-    runs-on: windows-latest
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    
-    - name: Install DocFX
-      run: dotnet tool install -g docfx
-      
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    
+    - name: Install DocFX
+      run: dotnet tool install -g docfx
+      
+    - name: Build Library
+      run: dotnet build -c Debug -f net35 .\Lib.Harmony\Lib.Harmony.csproj
+      
+    - name: Build Documentation
+      run: docfx Documentation/docfx.json
+      
+    - name: Install Python dependencies
+      run: pip install pyyaml
+      
+    - name: Generate LLM Pack
+      run: python scripts/generate_llm_pack.py
+      
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/master'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+        force_orphan: true
     - name: Build Library
       run: dotnet build -c Debug -f net35 .\Lib.Harmony\Lib.Harmony.csproj
       
@@ -42,4 +61,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs
-        force_orphan: true
+        force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,39 +1,45 @@
-name: Build and Deploy Documentation
-
-on:
+name: Build and Deploy Documentation
+
+on:
   push:
     branches: [ master ]
     paths:
       - 'Documentation/**'
       - 'Harmony/**'
-      - 'Lib.Harmony/**'
+      - 'scripts/generate_llm_pack.py'
       - '.github/workflows/docs.yml'
-
-jobs:
-  build:
-    runs-on: windows-latest
-    
-    steps:
-    - uses: actions/checkout@v3
-    
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    
-    - name: Install DocFX
-      run: dotnet tool install -g docfx
-      
-    - name: Build Library
-      run: dotnet build -c Debug -f net35 .\Lib.Harmony\Lib.Harmony.csproj
-      
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    
+    - name: Install DocFX
+      run: dotnet tool install -g docfx
+      
+    - name: Build Library
+      run: dotnet build -c Debug -f net35 .\Lib.Harmony\Lib.Harmony.csproj
+      
     - name: Build Documentation
       run: docfx Documentation/docfx.json
-      
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/master'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
-        force_orphan: true
+
+    - name: Install Python dependencies
+      run: pip install pyyaml
+
+    - name: Generate LLM Pack
+      run: python scripts/generate_llm_pack.py
+      
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/master'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+        force_orphan: true

--- a/scripts/generate_llm_pack.py
+++ b/scripts/generate_llm_pack.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import json
+
+import yaml
+
+OUT_DIR = Path('docs', 'llm-pack')
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+OUT_FILE = OUT_DIR / 'harmony.cards.jsonl'
+
+cards = []
+
+# API
+for path in Path('Documentation/api').rglob('*.yml'):
+	with path.open(encoding='utf-8') as f:
+		data = yaml.safe_load(f)
+	for item in data.get('items', []):
+		uid = item.get('uid')
+		kind = (item.get('type') or '').lower()
+		if not uid or not kind:
+			continue
+		summary = item.get('summary')
+		signature = item.get('syntax', {}).get('content')
+		remarks = item.get('remarks')
+		parent = item.get('parent')
+		doc_page = uid if not parent or parent == 'HarmonyLib' else parent
+		doc_url = f'https://harmony.pardeike.net/docs/api/{doc_page}.html'
+		cards.append({
+			'id': uid,
+			'kind': kind,
+			'summary': summary,
+			'signature': signature,
+			'remarks': remarks,
+			'doc_url': doc_url,
+			'examples': None
+		})
+
+# Articles
+for path in Path('Documentation/articles').rglob('*.md'):
+	with path.open(encoding='utf-8') as f:
+		lines = [line.strip() for line in f]
+	lines = [l for l in lines if l]
+	if not lines:
+		continue
+	summary = lines[0]
+	remarks = '\n'.join(lines[1:5]) if len(lines) > 1 else None
+	rel = path.relative_to('Documentation')
+	slug = rel.with_suffix('').as_posix()
+	doc_url = f'https://harmony.pardeike.net/docs/{slug}.html'
+	cards.append({
+		'id': slug,
+		'kind': 'article',
+		'summary': summary,
+		'signature': None,
+		'remarks': remarks,
+		'doc_url': doc_url,
+		'examples': None
+	})
+
+with OUT_FILE.open('w', encoding='utf-8') as out:
+	for card in cards:
+		out.write(json.dumps(card, ensure_ascii=False) + '\n')

--- a/scripts/generate_llm_pack.py
+++ b/scripts/generate_llm_pack.py
@@ -23,8 +23,12 @@ for path in Path('Documentation/api').rglob('*.yml'):
 		signature = item.get('syntax', {}).get('content')
 		remarks = item.get('remarks')
 		parent = item.get('parent')
-		doc_page = uid if not parent or parent == 'HarmonyLib' else parent
-		doc_url = f'https://harmony.pardeike.net/docs/api/{doc_page}.html'
+		href = item.get('href')
+		if href:
+			doc_url = f'https://harmony.pardeike.net/docs/{href.lstrip("/")}'
+		else:
+			doc_page = uid if not parent or parent == 'HarmonyLib' else parent
+			doc_url = f'https://harmony.pardeike.net/docs/api/{doc_page}.html'
 		cards.append({
 			'id': uid,
 			'kind': kind,


### PR DESCRIPTION
## Summary
- build llm-pack JSONL from API YAML and markdown articles
- extend docs workflow to publish llm-pack for HarmonyBot
- refactor llm-pack generator using pathlib and add executable header

## Testing
- `dotnet format --verbosity minimal`
- `dotnet test HarmonyTests/HarmonyTests.csproj -c Release -f net9.0`


------
https://chatgpt.com/codex/tasks/task_e_68bae3197f5883299dc9a33af7e46204