### PR TITLE
Fix CI tooling for .NET 10 on Windows and macOS Mono

### DIFF
--- a/.github/actions/test-setup-dotnet-windows/action.yml
+++ b/.github/actions/test-setup-dotnet-windows/action.yml
@@ -15,6 +15,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get .NET SDK Version
+      id: get-sdk-version
+      run: |
+        $global = Get-Content "${{ github.workspace }}/global.json" -Raw | ConvertFrom-Json;
+        "version=$($global.sdk.version)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append;
+      shell: pwsh
+
     - name: Get .NET Channel for ${{inputs.target_framework}}
       uses: ./.github/actions/get-dotnet-channel
       id: get_channel
@@ -31,9 +38,12 @@ runs:
     - name: Setup .NET ${{inputs.architecture}}
       run: |
         Invoke-WebRequest 'https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1;
+        if ('${{steps.get-sdk-version.outputs.version}}' -ne '') {
+          .\dotnet-install.ps1 -Version '${{steps.get-sdk-version.outputs.version}}' -SkipNonVersionedFiles -NoPath -Architecture ${{inputs.architecture}} -InstallDir "${{steps.get-program-files.outputs.path}}/dotnet";
+        }
         .\dotnet-install.ps1 -Runtime dotnet -SkipNonVersionedFiles -NoPath -Channel LTS -Architecture ${{inputs.architecture}} -InstallDir "${{steps.get-program-files.outputs.path}}/dotnet";
         .\dotnet-install.ps1 -Runtime dotnet -SkipNonVersionedFiles -NoPath -Channel STS -Architecture ${{inputs.architecture}} -InstallDir "${{steps.get-program-files.outputs.path}}/dotnet";
-        
+
         $channel = "${{steps.get_channel.outputs.channel}}";
         if ($channel -ne '') {
           .\dotnet-install.ps1 -Runtime dotnet -SkipNonVersionedFiles -NoPath -Channel $channel -Architecture ${{inputs.architecture}} -InstallDir "${{steps.get-program-files.outputs.path}}/dotnet";

--- a/.github/workflows/test-unix-mono.yml
+++ b/.github/workflows/test-unix-mono.yml
@@ -66,6 +66,12 @@ jobs:
         if: ${{ inputs.image == 'macos-14' && inputs.architecture == 'x64' }}
         run: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
 
+      - name: Install Mono on macOS
+        if: ${{ startsWith(inputs.os, 'macos') }}
+        run: |
+          brew update
+          brew install mono
+
       - name: Install Mono on Ubuntu
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
## Summary
- install the .NET SDK version from `global.json` on Windows test runners before adding runtime channels
- ensure macOS Mono jobs install the Mono runtime via Homebrew so framework tests can execute

## Testing
- dotnet test HarmonyTests/HarmonyTests.csproj -c Release -f net9.0 *(fails: missing Microsoft.NETCore.App 9.0 runtime in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e3932c348329891953df91d44dd2)