### PR TITLE
Avoid importing unused assembly Serialization.Formatters in .NET 9.0+

### DIFF
--- a/Harmony/Serialization/PatchInfoSerialization.cs
+++ b/Harmony/Serialization/PatchInfoSerialization.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization;
+#if !NET9_0_OR_GREATER
 using System.Runtime.Serialization.Formatters.Binary;
+#endif
 #if NET5_0_OR_GREATER
 using System.Text.Json;
 #endif
@@ -14,15 +16,13 @@ namespace HarmonyLib
 	{
 #if NET5_0_OR_GREATER
 		static readonly JsonSerializerOptions serializerOptions = new() { IncludeFields = true };
+#endif
+#if NET5_0_OR_GREATER && !NET9_0_OR_GREATER
 		internal static bool? useBinaryFormatter = null;
 		internal static bool UseBinaryFormatter
 		{
 			get
 			{
-#if NET9_0_OR_GREATER
-				// BinaryFormatter is obsolete in .NET 9, so we always use JSON serialization
-				return false;
-#else
 				if (!useBinaryFormatter.HasValue)
 				{
 					// https://github.com/dotnet/runtime/blob/208e377a5329ad6eb1db5e5fb9d4590fa50beadd/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/LocalAppContextSwitches.cs#L14
@@ -36,11 +36,11 @@ namespace HarmonyLib
 					}
 				}
 				return useBinaryFormatter.Value;
-#endif
 			}
 		}
 #endif
 
+#if !NET9_0_OR_GREATER
 		class Binder : SerializationBinder
 		{
 			/// <summary>Control the binding of a serialized object to a type</summary>
@@ -63,6 +63,7 @@ namespace HarmonyLib
 			}
 		}
 		internal static readonly BinaryFormatter binaryFormatter = new() { Binder = new Binder() };
+#endif
 
 		/// <summary>Serializes a patch info</summary>
 		/// <param name="patchInfo">The <see cref="PatchInfo"/></param>
@@ -70,17 +71,21 @@ namespace HarmonyLib
 		///
 		internal static byte[] Serialize(this PatchInfo patchInfo)
 		{
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !NET9_0_OR_GREATER
 			if (UseBinaryFormatter)
 			{
 #endif
+#if !NET9_0_OR_GREATER
 			using var streamMemory = new MemoryStream();
 			binaryFormatter.Serialize(streamMemory, patchInfo);
 			return streamMemory.ToArray();
-#if NET5_0_OR_GREATER
+#endif
+#if NET5_0_OR_GREATER && !NET9_0_OR_GREATER
 			}
 			else
-				return JsonSerializer.SerializeToUtf8Bytes(patchInfo);
+#endif
+#if NET5_0_OR_GREATER
+			return JsonSerializer.SerializeToUtf8Bytes(patchInfo);
 #endif
 		}
 
@@ -90,15 +95,19 @@ namespace HarmonyLib
 		///
 		internal static PatchInfo Deserialize(byte[] bytes)
 		{
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !NET9_0_OR_GREATER
 			if (UseBinaryFormatter)
 			{
 #endif
+#if !NET9_0_OR_GREATER
 			using var streamMemory = new MemoryStream(bytes);
 			return (PatchInfo)binaryFormatter.Deserialize(streamMemory);
-#if NET5_0_OR_GREATER
+#endif
+#if NET5_0_OR_GREATER && !NET9_0_OR_GREATER
 			}
 			else
+#endif
+#if NET5_0_OR_GREATER
 			{
 				return JsonSerializer.Deserialize<PatchInfo>(bytes, serializerOptions);
 			}

--- a/HarmonyTests/Extras/PatchSerialization.cs
+++ b/HarmonyTests/Extras/PatchSerialization.cs
@@ -49,7 +49,9 @@ namespace HarmonyTests.Extras
 			patchInfo.AddInnerPostfixes("innerpostfixes", [hMethod]);
 			patchInfo.VersionCount = 123;
 
+#if !NET9_0_OR_GREATER
 			PatchInfoSerialization.useBinaryFormatter = false;
+#endif
 			var result = PatchInfoSerialization.Serialize(patchInfo);
 			var resString = Encoding.UTF8.GetString(result, 0, result.Length);
 			Assert.AreEqual(ExpectedJSON(), resString);
@@ -58,7 +60,9 @@ namespace HarmonyTests.Extras
 		[Test]
 		public void Deserialize()
 		{
+#if !NET9_0_OR_GREATER
 			PatchInfoSerialization.useBinaryFormatter = false;
+#endif
 
 			Assert.AreEqual(GetFixes(new PatchInfo()).Length, fixNames.Length);
 


### PR DESCRIPTION
The assembly 'System.Runtime.Serialization.Formatters.Binary' is banned by Paint.NET and attempting to load Harmony in Paint.NET through its effects system is impossible. Since this assembly isn't used in .NET 9.0+, I used the preprocessor to avoid loading it at all in .NET 9.0+. This allows Harmony to load in Paint.NET.

Here is what Paint.NET showed in its Plugin Errors section before this patch.
<img width="1427" height="712" alt="image" src="https://github.com/user-attachments/assets/152ea887-3485-4554-8457-1b4aa84096bd" />

And after. The error comes from my DLL and not 0Harmony.dll being rejected.
<img width="688" height="527" alt="image" src="https://github.com/user-attachments/assets/d04b8f91-f5ca-41d3-b5de-c6eb6a39951b" />
